### PR TITLE
Fix link and punctuation

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -11,7 +11,7 @@ title: Contact
 
 *NOTE* Before e-mailing, please refer to the [FAQ](/docs/faq).
 
-Henrik, the project founder, can be reached on [hrydgard+ppsspp@gmail.com](mailto:hrydgard+ppsspp@gmail.com)
+Henrik, the project founder, can be reached on [hrydgard+ppsspp@gmail.com](mailto:hrydgard+ppsspp@gmail.com).
 
 ## Discord
 
@@ -21,9 +21,9 @@ Henrik, the project founder, can be reached on [hrydgard+ppsspp@gmail.com](mailt
 
 Henrik's own company is [Millionth Line AB](https://www.millionthline.com).
 He used to work at [Embark Studios](https://www.embark-studios.com/) until recently.
-Before that he worked at NVIDIA, and previously [Soundtrack Your Brand](https://www.soundtrackyourbrand.com/)
+Before that he worked at NVIDIA, and previously [Soundtrack Your Brand](https://www.soundtrackyourbrand.com/).
 
-This website was built with [Docusaurus](https://docusaurus.io/) (with [https://github.com/hrydgard/ppsspp-site/](some modifications)).
+This website was built with [Docusaurus](https://docusaurus.io/) (with [some modifications](https://github.com/hrydgard/ppsspp-site/)).
 
 ## Twitter
 


### PR DESCRIPTION
The arguments for the link syntax were switched and thus produced a broken link.

The rest is just nitpicks, can be ignored if necessary.