### PR TITLE
Prevent text clipping on download buttons

### DIFF
--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -33,7 +33,6 @@
     margin: 8px 0px;
     text-align: center;
     user-select: none;
-    white-space: nowrap;
     overflow: hidden;
 }
 


### PR DESCRIPTION
Before:  
![image](https://github.com/user-attachments/assets/7a95f434-2835-41d9-87ca-86204e2d677f)  
After:  
![image](https://github.com/user-attachments/assets/793e605e-13eb-4a9f-a0a0-35cdb5921700)
