### PR TITLE
Dynamically list blog page author pic and links

### DIFF
--- a/data/authors.json
+++ b/data/authors.json
@@ -2,7 +2,9 @@
   "hrydgard": {
     "name": "Henrik Rydgård",
     "title": "PPSSPP Creator",
-    "url": "https://github.com/hrydgard",
-    "image_url": "https://github.com/hrydgard.png"
+    "image_url": "https://github.com/hrydgard.png",
+    "url": "https://www.henrikrydgard.com/",
+    "twitter_url": "https://x.com/henrikrydgard",
+    "github_url": "https://github.com/hrydgard"
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Author {
     url: String,
     image_url: String,
     title: String,
+    twitter_url: String,
+    github_url: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -43,7 +43,8 @@ img.prev-ver-item {
 img.icon-48,
 img.icon-36,
 img.icon-32,
-img.icon-24 {
+img.icon-24,
+img.icon-author {
     display: inline-flex;
     justify-content: center;
     vertical-align: middle;
@@ -55,6 +56,18 @@ img.icon-48 { height: 48px; width: 48px; }
 img.icon-36 { height: 36px; width: 36px; }
 img.icon-32 { height: 32px; width: 32px; }
 img.icon-24 { height: 24px; width: 24px; }
+
+img.icon-author {
+    height: 24px;
+    width: 24px;
+    border-radius: 50%;
+}
+
+i.icon-author {
+    display: inline;
+    vertical-align: middle;
+    font-size: 24px;
+}
 
 img.icon-link {
     display: inline-flex;

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -12,16 +12,20 @@
         {{ /if }}
         <div class="article-infos">
             <ul>
-                <li><i class="fas fa-user-circle"></i> <b>
-                        {{#with (lookup globals.authors meta.author)}}
-                        {{name}}
-                        {{/with}}</b>
+                {{#with (lookup globals.authors meta.author)}}
+                <li>
+                    {{#if image_url}}<img src="{{image_url}}" class="icon-author">
+                    {{else}}<i class="fas fa-user-circle icon-author"></i>
+                    {{/if}}
+                    <b>{{name}}</b>
                 </li>
-                <li><i class="fas fa-folder"></i> <b>{{#each meta.tags}}<a
+                <li><i class="fas fa-folder"></i> <b>{{#each ../meta.tags}}<a
                             href="/{{../meta.section}}/tags/{{this}}">{{this}}</a> {{/each}} </b></li>
-                <li><i class="fas fa-clock"></i> <b>{{ meta.date }}</b></li>
-                <li><a href="https://x.com/henrikrydgard"><i class="fab fa-x-twitter"></i></a></li>
-                <li><a href="https://www.github.com/hrydgard"><i class="fab fa-github-alt"></i></a></li>
+                <li><i class="fas fa-clock"></i> <b>{{ ../meta.date }}</b></li>
+                {{#if url}}<li><a href="{{url}}"><i class="fas fa-link"></i></a></li>{{/if}}
+                {{#if twitter_url}}<li><a href="{{twitter_url}}"><i class="fab fa-x-twitter"></i></a></li>{{/if}}
+                {{#if github_url}}<li><a href="{{github_url}}"><i class="fab fa-github-alt"></i></a></li>{{/if}}
+                {{/with}}
             </ul>
         </div>
         <div class="ms-article-title">


### PR DESCRIPTION
Makes blog page author picture and links listed dynamically. Links are only displayed if they are not empty in `authors.json` -- the bottom picture showcases empty picture and empty personal website link.
![image](https://github.com/user-attachments/assets/e02ae91b-7d0f-43e6-bf9a-4e5a956fbd24)

I don't know whether this is needed or wanted but I saw the opportunity for a possible improvement, so...

Might probably need some rework once you want to support multiple authors per page (if ever).