### PR TITLE
Fix WipEout Pure screenshot caption

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,7 +1,7 @@
 [
     {
         "filename": "wipeoutpure.jpg",
-        "description": "Wipeout Pulse"
+        "description": "WipEout Pure"
     },
     {
         "filename": "burnoutdominator.jpg",


### PR DESCRIPTION
The current site's Media section captions a screenshot of WipEout Pure as "Wipeout Pulse". This pull request fixes that.