### PR TITLE
Hide comments on hbs pages

### DIFF
--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -10,7 +10,7 @@
     </div>
 
     <div class="row">
-        <!-- We now over the platforms -->
+        {{!-- We now over the platforms --}}
         {{#each globals.platforms}}
         <div class="col-4">
             <div class="card">

--- a/pages/getgames.hbs
+++ b/pages/getgames.hbs
@@ -47,4 +47,5 @@
     {{> unit }}
 
 </div>
+
 {{> common_footer this}}

--- a/pages/getgames_ios.hbs
+++ b/pages/getgames_ios.hbs
@@ -35,4 +35,5 @@
     <p>That's it!</p>
 
 </div>
+
 {{> common_footer this}}

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -86,10 +86,8 @@
         </div>
     </div>
 
-    <!-- TODO: Show latest news here! -->
+    {{!-- TODO: Show latest news here! --}}
 
 </div>
-
-
 
 {{> common_footer this}}

--- a/pages/login.hbs
+++ b/pages/login.hbs
@@ -1,6 +1,6 @@
 {{> common_header this title="Login" description="Login form"}}
 
-<!-- This takes care of /loginbykey duties too. That's a redirect. -->
+{{!-- This takes care of /loginbykey duties too. That's a redirect. --}}
 
 <div class="container">
     <div class="row">

--- a/pages/media.hbs
+++ b/pages/media.hbs
@@ -2,9 +2,9 @@
 
 <div class="container">
     <h2>Screenshots</h2>
-    <!-- Slideshow container -->
+    {{!-- Slideshow container --}}
     <div class="slideshow-container">
-        <!-- Full-width images with number and caption text -->
+        {{!-- Full-width images with number and caption text --}}
         {{#each globals.screenshots}}
         <div class="mySlides fade">
             <img src="/static/img/screenshots/{{filename}}" style="width:100%" onclick="plusSlides(1)">
@@ -12,12 +12,12 @@
         </div>
         {{/each}}
 
-        <!-- Next and previous buttons -->
+        {{!-- Next and previous buttons --}}
         <a class="prev" onclick="plusSlides(-1)">&#10094;</a>
         <a class="next" onclick="plusSlides(1)">&#10095;</a>
     </div>
     <br>
-    <!-- The dots/circles -->
+    {{!-- The dots/circles --}}
     <div style="text-align:center">
         {{#each globals.screenshots}}
         <span class="slideshow-dot" onclick="currentSlide({{index}})"></span>

--- a/pages/thankyou.hbs
+++ b/pages/thankyou.hbs
@@ -5,7 +5,7 @@
         <div class="col-10">
             <h1>Thank you for buying PPSSPP Gold!</h1>
 
-            <!-- The rest of the text is in account.js -->
+            {{!-- The rest of the text is in account.js --}}
 
             <div id="purchaseStatus">
                 <p>Check your e-mail for your confirmation and login link.</p>

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -1,7 +1,7 @@
 <div>
     <div class="article">
         {{ #if picture_title }}
-        <!-- unused -->
+        {{!-- unused --}}
         <div class="ms-article-picture">
             <img src="https://www.zupimages.net/up/22/08/uitq.png" alt="background">
             <div class="ms-article-picture-overlay"></div>

--- a/template/blog_tags.hbs
+++ b/template/blog_tags.hbs
@@ -1,4 +1,4 @@
-<!-- tag listing -->
+{{!-- tag listing --}}
 
 <h1>Article tags</h1>
 

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -68,9 +68,7 @@
 
         <section class="contents">
             <div class="burger-sidebar hidden" id="rootSidebar">
-                <!-- We repeat all the same stuff again, but add Login.
-                better than crazy CSS tricks...
-                 -->
+                {{!-- We repeat all the same stuff again, but add Login. Better than crazy CSS tricks... --}}
                 <ul class="burger-menu">
                     {{#each top_nav}}
                     <li><a href="{{url}}"

--- a/template/unit.hbs
+++ b/template/unit.hbs
@@ -1,6 +1,6 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3281131109267988"
     crossorigin="anonymous"></script>
-<!-- Responsive Black -->
+{{!-- Responsive Black --}}
 <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-3281131109267988" data-ad-slot="6642932432"
     data-ad-format="auto"></ins>
 <script>


### PR DESCRIPTION
This changes comments on hbs pages so that they aren't translated into HTML.

A couple of these comments are unnecessary, but I didn't remove any.

In particular:
- `download.hbs` the code makes this obvious
- `index.hbs` the latest news are already listed 2 sections above. Did you mean to display an entire news article or is this comment just leftover?
- `media.hbs` the code makes this obvious
- `blog_tags.hbs` the code makes this obvious