### PR TITLE
Add inapp class, buygold_inapp template, misc changes

### DIFF
--- a/docs/development/wsl.md
+++ b/docs/development/wsl.md
@@ -10,7 +10,9 @@ Recently, it has even added graphics support and it's now possible to build and 
 
 * Check out the PPSSPP repository:
 
-  > git clone git@github.com:hrydgard/ppsspp.git --recursive
+  ```sh
+  git clone git@github.com:hrydgard/ppsspp.git --recursive
+  ```
 
 * Install the usual dependencies documented [here](https://github.com/hrydgard/ppsspp/wiki/Build-instructions#building-with-cmake-other-platforms-eg-linux) (plus cmake).
 
@@ -22,15 +24,17 @@ Recently, it has even added graphics support and it's now possible to build and 
 
 In your WSL directory where you checked out the PPSSPP git repo, from terminal, just:
 
-> code .
+```sh
+code .
+```
 
-PPSSPP now provides .vscode/tasks.json and .vscode/launch.json for your convenience, so debugging should "just work".
+PPSSPP now provides `.vscode/tasks.json` and `.vscode/launch.json` for your convenience, so debugging should "just work".
 
-The build task just runs a debug build, important to be aware of. Change it to --release or add an additional task if desired.
+The build task just runs a debug build, important to be aware of. Change it to `--release` or add an additional task if desired.
 
 ## Valgrind
 
-Here's an example where we both use suppressions, and generate new ones (that you can then take from suppressions.log and simplify and copy to valgrind-wsl2.supp):
+Here's an example where we both use suppressions, and generate new ones (that you can then take from `suppressions.log` and simplify and copy to `valgrind-wsl2.supp`):
 
 ```sh
 valgrind --suppressions=SDL/valgrind-wsl2.supp --gen-suppressions=all --log-file=suppressions.log build/PPSSPPSDL

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -1,5 +1,4 @@
-{{> common_header this title="Buy PPSSPP Gold" description="Buy PPSSPP Gold" fastspring="true"
-noAds="true" }}
+{{> common_header this title="Buy PPSSPP Gold" description="Buy PPSSPP Gold" fastspring="true" noAds="true" }}
 
 <div class="container">
     <h1>Buy PPSSPP Gold {{ globals.app_version }}</h1>
@@ -23,8 +22,10 @@ noAds="true" }}
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS&nbsp;<img src="/static/img/icons/ios.svg"
             alt="ios icon" class="icon-36"></h2>
 
-    <p>From 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just
-    <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903">download that</a> and click the Buy PPSSPP Gold button!</p>
+    <p>Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just
+        <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903">download that</a>
+        and click the {{> buygold_inapp }} button!
+    </p>
 
     <h2 class="center-vertical">Buy PPSSPP
         Gold for Windows/macOS&nbsp;<img src="/static/img/icons/windows.svg" alt="windows icon" class="icon-36">
@@ -64,4 +65,4 @@ noAds="true" }}
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -11,7 +11,7 @@
     </div>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for Android&nbsp;<img src="/static/img/icons/android.svg"
-            alt="android icon" class="icon-36"></h2>
+            aria-hidden="true" class="icon-36"></h2>
     <a href="https://play.google.com/store/apps/details?id=org.ppsspp.ppssppgold"
         class="download-button button-gold button-block">
         <div class="button-contents"><img src="/static/img/platform/googleplay-badge.svg"
@@ -20,7 +20,7 @@
     </a>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS&nbsp;<img src="/static/img/icons/ios.svg"
-            alt="ios icon" class="icon-36"></h2>
+            aria-hidden="true" class="icon-36"></h2>
 
     <p>Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just
         <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903">download that</a>
@@ -28,8 +28,8 @@
     </p>
 
     <h2 class="center-vertical">Buy PPSSPP
-        Gold for Windows/macOS&nbsp;<img src="/static/img/icons/windows.svg" alt="windows icon" class="icon-36">
-            &nbsp;<img src="/static/img/icons/macos.svg" alt="mac os icon" class="icon-36"/></h2>
+        Gold for Windows/macOS&nbsp;<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-36">
+            &nbsp;<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-36"/></h2>
 
     <p></p>
 

--- a/pages/buygold_ios.hbs
+++ b/pages/buygold_ios.hbs
@@ -1,16 +1,15 @@
-{{> common_header this title="Buy PPSSPP Gold" description="Buy PPSSPP Gold" fastspring="true"
-noAds="true" }}
+{{> common_header this title="Buy PPSSPP Gold" description="Buy PPSSPP Gold" fastspring="true" noAds="true" }}
 
 <div class="container">
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS</h2>
 
-    <p>From 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just:</p>
+    <p>Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just:</p>
 
     <p><a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903"><img src="/static/img/icons/ios.svg" class="icon-36" alt="ios icon">&nbsp;Download PPSSPP on the App Store</a></p>
 
-    <p>Then start it up and click the "Buy PPSSPP Gold" button in the app!</p>
+    <p>Then start it up and click the {{> buygold_inapp }} button in the app!</p>
 
     <p>For other platforms, <a href="/buygold">see here</a>.</p>
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/buygold_ios.hbs
+++ b/pages/buygold_ios.hbs
@@ -5,7 +5,7 @@
 
     <p>Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just:</p>
 
-    <p><a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903"><img src="/static/img/icons/ios.svg" class="icon-36" alt="ios icon">&nbsp;Download PPSSPP on the App Store</a></p>
+    <p><a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903"><img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-36">&nbsp;Download PPSSPP on the App Store</a></p>
 
     <p>Then start it up and click the {{> buygold_inapp }} button in the app!</p>
 

--- a/pages/contact.hbs
+++ b/pages/contact.hbs
@@ -1,17 +1,14 @@
-{{> common_header this title="Contact" description="Contact email, X accounts, Twitter accounts, Discord invite link, etc" }}
+{{> common_header this title="Contact" description="Community and social links, contact e-mail" }}
 
 <div class="container">
     <div class="row">
         <div class="col-mb-6">
-            <h1>Community, contact info, and links</h1>
+            <h1>Community, contact info and links</h1>
             <h2>PPSSPP Forums</h2>
             <ul>
                 <li>English and international: <a href="https://forums.ppsspp.org/">PPSSPP Forums</a></li>
                 <li>Chinese: <a href="https://tieba.baidu.com/f?kw=ppsspp&fr=ala0">PPSSPP Tieba community</a></li>
             </ul>
-            <h2>E-mail</h2>
-            <p>*NOTE* Before e-mailing, please refer to the <a href="/docs/faq">FAQ</a>.</p>
-            <p>Henrik, the project founder, can be reached on <code>hrydgard+ppsspp@gmail.com</code>.</p>
 
             <h2>Discord</h2>
             <p>The PPSSPP Discord is the easiest way to get in touch with other people in the community, and is also
@@ -19,6 +16,10 @@
 
             <iframe src="https://discordapp.com/widget?id=293316141479362560&theme=dark" width="350" height="500"
                 allowtransparency="true" frameborder="0"></iframe>
+
+            <h2>E-mail</h2>
+            <p>*NOTE* Before e-mailing, please refer to the <a href="/docs/faq">FAQ</a>.</p>
+            <p>Henrik, the project founder, can be reached on <a href="mailto:hrydgard+ppsspp@gmail.com">hrydgard+ppsspp@gmail.com</a>.</p>
 
             <h2>Web</h2>
             <p>Henrik's own company is <a href="https://www.millionthline.com">Millionth Line AB</a>.</p>
@@ -42,4 +43,4 @@
     </div>
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/devbuilds.hbs
+++ b/pages/devbuilds.hbs
@@ -1,13 +1,10 @@
-{{> common_header this title="Development Builds" description="Download development builds of PPSSPP"}}
+{{> common_header this title="Development Builds" description="Download development builds of PPSSPP" }}
 
 <div class="container">
     <h1>PPSSPP Development Builds</h1>
-    <p>Please note that these development builds can be unstable - if one doesn't work, try an earlier one.
-        And backup your save games!</p>
     <div class="alert alert-warning">
-        The Android APKs here are not compatible with the builds from Orphis' old build server - meaning
-        that you probably have to uninstall and reinstall to switch to these builds. Make sure you have
-        backed up your save games.
+        Please note that these development builds can be unstable - if one doesn't work, try an earlier one.
+        Always backup your save games!
     </div>
     <p>Development builds for more platforms will be added soon.</p>
     <p><a href="/buildbotstatus">Buildbot status</a></p>
@@ -25,4 +22,4 @@
     g_downloadPage = true;
 </script>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -1,4 +1,4 @@
-{{> common_header this title="Download" description="Download PPSSPP for Android, Windows, Mac, iOS"}}
+{{> common_header this title="Download" description="Download PPSSPP for Android, Windows, macOS, Linux, iOS" }}
 
 <div class="container">
     <h1>Download PPSSPP</h1>
@@ -10,7 +10,6 @@
     </div>
 
     <div class="row">
-        {{!-- We now over the platforms --}}
         {{#each globals.platforms}}
         <div class="col-4">
             <div class="card">
@@ -107,15 +106,11 @@
 
     <h2>Development builds</h2>
 
-    <p>Please note that these development builds can be unstable - if one doesn't work, try an earlier one. And backup
-        your save games!</p>
-    <p>Development builds for more platforms will be added soon.</p>
-
     <div class="alert alert-warning">
-        The Android APKs here are not compatible with the builds from Orphis' old build server - meaning
-        that you probably have to uninstall and reinstall to switch to these builds. Make sure you have
-        backed up your save games.
+        Please note that these development builds can be unstable - if one doesn't work, try an earlier one.
+        Always backup your save games!
     </div>
+    <p>Development builds for more platforms will be added soon.</p>
 
     <p><a href="/devbuilds">Full list of development builds</a></p>
 
@@ -127,4 +122,4 @@
     </script>
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -15,7 +15,7 @@
             <div class="card">
                 <div class="card-title">
                     {{ #if platform_badge }}
-                    <img src="/static/img/icons/{{platform_badge}}" class="icon-36">
+                    <img src="/static/img/icons/{{platform_badge}}" aria-hidden="true" class="icon-36">
                     {{ /if}}
                     <h2>{{ title }}</h2>
                 </div>
@@ -31,7 +31,7 @@
                             }}href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
                             <div class="button-contents">
                                 {{ #if icon }}
-                                <img src="/static/img/platform/{{icon}}" class="icon-32">&nbsp;
+                                <img src="/static/img/platform/{{icon}}" aria-hidden="true" class="icon-32">
                                 {{ /if }}
                                 {{ #if url }}{{name}}{{ /if }}
                                 {{ #if download_url }}{{name}}{{ /if }}

--- a/pages/getgames.hbs
+++ b/pages/getgames.hbs
@@ -1,8 +1,8 @@
-{{> common_header this title="How to get games" description="How to get games"}}
+{{> common_header this title="How to get games" description="How to get games" }}
 
 <div class="container">
 
-    <h1 style="padding-top: 10px">How to get games for PPSSPP</h1>
+    <h1>How to get games for PPSSPP</h1>
 
     <h3>What are they?</h3>
 
@@ -19,11 +19,12 @@
 
     <h3>How do I get them on my device?</h3>
 
+    <h4>Windows/macOS</h4>
+    <p>If you are running the Windows or macOS version of PPSSPP and you have the game you want to run as an ISO or CSO file,
+        just do File-&gt;Load, or use the <b class="inapp">Games</b> tab to navigate to your game.
+        Clicking "<b class="inapp">..</b>" moves up a directory level.</p>
+
     <h4>Android</h4>
-
-    <p>If you are running the PC version of PPSSPP and you have the game you want to run as an ISO or CSO file, just do
-        File-Load, or use the Games tab to navigate to your game. Clicking ".." moves up a directory level.</p>
-
     <p>If you want to play on your Android device (or other portable), then follow these steps:</p>
 
     <ul>
@@ -32,8 +33,8 @@
             connected via USB cable.</li>
         <li>The device should show up in Windows Explorer. Now simply copy over the files to somewhere easy to
             remember - for example, create a folder called "PSP ISO" and copy your ISO and CSO files there.</li>
-        <li>Now, start PPSSPP, navigate to your new ISOs on the Games tab, then click the game, which now should
-            show up with an icon.</li>
+        <li>Now, start PPSSPP, navigate to your new ISOs on the <b class="inapp">Games</b> tab, then click the game,
+            which now should show up with an icon.</li>
         <li>The game should now start.</li>
     </ul>
 
@@ -42,10 +43,8 @@
     <p>For iOS instructions and more details, <a href="/docs/getting-started/installing-games-android">click here</a>.
     </p>
 
-    <p>That's it!</p>
-
     {{> unit }}
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/getgames_ios.hbs
+++ b/pages/getgames_ios.hbs
@@ -1,8 +1,8 @@
-{{> common_header this title="How to get games" description="How to get games"}}
+{{> common_header this title="How to get games" description="How to get games" }}
 
 <div class="container">
 
-    <h1 style="padding-top: 10px">How to get games for PPSSPP</h1>
+    <h1>How to get games for PPSSPP</h1>
 
     <h3>What are they?</h3>
 
@@ -22,18 +22,17 @@
     <h4>Mac instructions</h4>
 
     <ol>
-        <li>1. Connect your iOS device (iPhone or iPad) via USB to your Mac.</li>
-        <li>2. On your Mac, open the device in Finder. Click the Files tab, then you should see PPSSPP and/or PPSSPP
-            Gold listed.</li>
-        <li>3. Drag your ISO files into the app. To see them, you may have to click the Refresh button in the app, if
+        <li>Connect your iOS device (iPhone or iPad) via USB to your Mac.</li>
+        <li>On your Mac, open the device in Finder. Click the <b class="inapp">Files</b> tab, then you should see PPSSPP listed.</li>
+        <li>Drag your ISO files into the app. To see them, you may have to click the Refresh icon in the app, if
             it's running.</li>
     </ol>
 
-    <p>After this, the ISO files will be located on the virtual "memory stick". Just pick them from the Games tab (click
-        Home if you can't find the files).</p>
+    <p>After this, the ISO files will be located on the virtual "memory stick". Just pick them from the
+        <b class="inapp">Games</b> tab (click the Home icon if you can't find the files).</p>
 
     <p>That's it!</p>
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/gethomebrew.hbs
+++ b/pages/gethomebrew.hbs
@@ -1,8 +1,8 @@
-{{> common_header this title="How to get homebrew and demos" description="How to get homebrew and demos"}}
+{{> common_header this title="How to get homebrew and demos" description="How to get homebrew and demos" }}
 
 <div class="container">
 
-    <h1 style="padding-top: 10px">Demos and homebrew for PPSSPP</h1>
+    <h1>Demos and homebrew for PPSSPP</h1>
 
     <h2>PSP Demos</h2>
     <p>Many game companies released downloadable demo versions of their games for the PSP.
@@ -28,8 +28,8 @@
     </ul>
 
     <h3>How do I get them on my device?</h3>
-    <p>If you have manually downloaded homebrew, unzip it and put the game folder in PSP/GAME in your memstick
-        directory.
+    <p>If you have manually downloaded homebrew, unzip it and put the game folder in <code>PSP/GAME</code>
+        in your memstick directory.
     </p>
 
     <p>
@@ -40,4 +40,4 @@
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/gethomebrew_ios.hbs
+++ b/pages/gethomebrew_ios.hbs
@@ -1,8 +1,8 @@
-{{> common_header this title="How to get homebrew and demos" description="How to get homebrew and demos"}}
+{{> common_header this title="How to get homebrew and demos" description="How to get homebrew and demos" }}
 
 <div class="container">
 
-    <h1 style="padding-top: 10px">Demos and homebrew for PPSSPP</h1>
+    <h1>Demos and homebrew for PPSSPP</h1>
 
     <h2>PSP Demos</h2>
     <p>Many game companies released downloadable demo versions of their games for the PSP.
@@ -28,8 +28,8 @@
     </ul>
 
     <h3>How do I get them on my device?</h3>
-    <p>If you have manually downloaded homebrew, unzip it and put the game folder in PSP/GAME in your memstick
-        directory (the app's Documents directory on iOS).
+    <p>If you have manually downloaded homebrew, unzip it and put the game folder in <code>PSP/GAME</code>
+        in your memstick directory (the app's Documents directory on iOS).
     </p>
 
     <p>
@@ -38,4 +38,4 @@
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -19,13 +19,14 @@
             <div class="col-4">
                 <a href="/download" class="hero-button download-button button-block">
                     <div class="button-contents">
-                        <img src="/static/img/platform/ppsspp-icon.png" class="icon-32">&nbsp;&nbsp;Download
+                        <img src="/static/img/platform/ppsspp-icon.png" aria-hidden="true" class="icon-32">
+                        Download
                     </div>
                 </a>
                 <a href="/buygold" class="hero-button download-button button-block">
                     <div class="button-contents">
-                        <img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-32">&nbsp;&nbsp;Buy
-                        PPSSPP Gold
+                        <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-32">
+                        Buy PPSSPP Gold
                     </div>
                 </a>
             </div>

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -1,4 +1,4 @@
-{{> common_header this title="PPSSPP - PSP emulator for Android, Windows, Linux, macOS, iOS"}}
+{{> common_header this title="PPSSPP - PSP emulator for Android, Windows, Linux, macOS, iOS" }}
 
 <header class="hero hero-banner">
     <div class='light x1'></div>
@@ -86,8 +86,6 @@
         </div>
     </div>
 
-    {{!-- TODO: Show latest news here! --}}
-
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/legacybuilds.hbs
+++ b/pages/legacybuilds.hbs
@@ -1,5 +1,4 @@
-{{> common_header this title="Ports, legacy builds and other downloads"
-description="Ports, legacy builds and other downloads"}}
+{{> common_header this title="Ports, legacy builds and other downloads" description="Ports, legacy builds and other downloads" }}
 
 <div class="container">
     <h1>Ports, legacy builds and other downloads</h1>
@@ -39,7 +38,8 @@ description="Ports, legacy builds and other downloads"}}
 
     <h3 class="center-vertical">Old Android&nbsp;<img src="/static/img/icons/androidlegacy.svg"
             alt="old android icon" class="icon-36"></h3>
-    <p>The last release that works on <strong>x86-32</strong> architecture devices is v1.15.4 from May, 2023. Technically newer versions may work too, but they will run less efficiently under ARM emulation on x86.</p>
+    <p>The last release to support <strong>x86-32</strong> architecture devices is v1.15.4 from May, 2023.
+        Technically newer versions may work too, but they will run less efficiently under ARM emulation on x86.</p>
     <p>PPSSPP 1.15.4 for Android: <a href="https://www.ppsspp.org/files/1_15_4/ppsspp.apk">Download APK</a></p>
 
     <p>The last release that works on <strong>ARMv6</strong> architecture (legacy armeabi) devices is v0.9.7.2 from February, 2014.</p>
@@ -91,4 +91,4 @@ description="Ports, legacy builds and other downloads"}}
 
 </div>
 
-{{> common_footer this}}
+{{> common_footer this }}

--- a/pages/legacybuilds.hbs
+++ b/pages/legacybuilds.hbs
@@ -4,7 +4,7 @@
     <h1>Ports, legacy builds and other downloads</h1>
 
     <h2 class="center-vertical">PPSSPP for Switch (homebrew)&nbsp;<img src="/static/img/icons/switch.svg"
-            alt="nintendo switch icon" class="icon-36"></h2>
+            aria-hidden="true" class="icon-36"></h2>
     <p>Ported to the Nintendo Switch by m4xw! See <a href="https://www.patreon.com/m4xwdev">m4xw's Patreon</a>.</p>
     <p>You'll need a Switch enabled for homebrew to run this (and a 7z unpacker). You won't find an explanation about
         that here!</p>
@@ -15,13 +15,13 @@
     <p><a href="https://www.ppsspp.org/files/1_9_0/ppsspp_switch.7z">Download PPSSPP 1.9 for Switch</a></p>
 
     <h2 class="center-vertical">Legacy Edition for Android&nbsp;<img src="/static/img/platform/ppsspp-icon-legacy.png"
-            alt="PPSSPP Legacy Edition" class="icon-36"></h2>
+            aria-hidden="true" class="icon-36"></h2>
     <p>The Legacy Edition for Android lets you use old permission rules on new devices, which can help Android TV
         devices without folder browsers.</p>
     <p><a href="/docs/reference/legacy-edition">PPSSPP Legacy Edition for Android</a>
 
     <h2 class="center-vertical">Cube test program&nbsp;<img src="/static/img/icons/cube.svg"
-            alt="cube icon" class="icon-36"></h2>
+            aria-hidden="true" class="icon-36"></h2>
     <p>A simple PSP program that draws a spinning cube. For testing that the emu works on your device before you dump
         your UMDs.</p>
     <p>For this testing, these days you can also just use the <a href="/docs/reference/homebrew-store-distribution">
@@ -37,7 +37,7 @@
     </div>
 
     <h3 class="center-vertical">Old Android&nbsp;<img src="/static/img/icons/androidlegacy.svg"
-            alt="old android icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>The last release to support <strong>x86-32</strong> architecture devices is v1.15.4 from May, 2023.
         Technically newer versions may work too, but they will run less efficiently under ARM emulation on x86.</p>
     <p>PPSSPP 1.15.4 for Android: <a href="https://www.ppsspp.org/files/1_15_4/ppsspp.apk">Download APK</a></p>
@@ -46,44 +46,44 @@
     <p>PPSSPP 0.9.7.2 for Android: <a href="https://www.ppsspp.org/files/0_9_7_2/ppsspp.apk">Download APK</a></p>
 
     <h3 class="center-vertical">DragonBox Pyra&nbsp;<img src="/static/img/icons/pyra.svg"
-            alt="dragonbox pyra icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>This is a DragonBox Pyra port of PPSSPP from January, 2021. Built by Wally.</p>
     <p><a href="https://pyra-handheld.com/repo/apps/31">DBP repository</a></p>
 
     <h3 class="center-vertical">Pandora&nbsp;<img src="/static/img/icons/pandora.svg"
-            alt="pandora icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>This is a Pandora port of PPSSPP. The last release is Build 55 from October, 2020 and is based on version 1.10.3.
         You will have to figure out how to install it. :) Thanks to ptitSeb!</p>
     <p><a href="http://repo.openpandora.org/?page=detail&app=ppsspp_ptitseb">OpenPandora repo</a></p>
 
     <h3 class="center-vertical">Old Windows&nbsp;<img src="/static/img/icons/windowslegacy.svg"
-            alt="old windows icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>The last release that works on <strong>Windows XP</strong> is 1.8 from March, 2019. Newer versions simply do not launch.</p>
     <p>PPSSPP 1.8 installer for Windows: <a href="https://www.ppsspp.org/files/1_8_0/PPSSPPSetup.exe">Download .exe</a></p>
     <p>PPSSPP 1.8 portable for Windows: <a href="https://www.ppsspp.org/files/1_8_0/ppsspp_win.zip">Download ZIP</a></p>
 
     <h3 class="center-vertical">BlackBerry 10&nbsp;<img src="/static/img/icons/blackberry.svg"
-            alt="blackberry icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>This is a BlackBerry 10 port of PPSSPP. Sideload the <code>.bar</code> from your computer using Sachesi or Chrome
         extension. Thanks to xsacha for doing the build!</p>
     <p>PPSSPP 0.9.9 for BlackBerry 10: <a href="https://www.ppsspp.org/files/0_9_9/PPSSPP-v0.9.9.bar">Download .bar</a></p>
 
     <h3 class="center-vertical">Symbian&nbsp;<img src="/static/img/icons/symbian.svg"
-            alt="symbian yellow heart icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>This is a Symbian port of PPSSPP. Thanks to xsacha for doing the build!</p>
     <p>PPSSPP 0.9.9 for Symbian: <a href="https://www.ppsspp.org/files/0_9_9/PPSSPP-v0.9.9.sis">Download .sis</a></p>
 
     <h3 class="center-vertical">MeeGo / Harmattan&nbsp;<img src="/static/img/icons/meego.svg"
-            alt="meego dot com icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>This is a MeeGo "Harmattan" port of PPSSPP for Nokia N9. Thanks to xsacha for doing the build!</p>
     <p>PPSSPP 0.9.5 for MeeGo: <a href="https://www.ppsspp.org/files/0_9_5/PPSSPP-v0.9.5.deb">Download .deb</a></p>
 
     <h3 class="center-vertical">Maemo 5 / Fremantle&nbsp;<img src="/static/img/icons/maemo.svg"
-            alt="maemo icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>Support for a Maemo 5 port for Nokia N900 was added by aapo in March, 2013. Unfortunately no builds remain.</p>
 
     <h3 class="center-vertical">Windows Phone 7&nbsp;<img src="/static/img/icons/windowsphone.svg"
-            alt="windows phone icon" class="icon-36"></h3>
+            aria-hidden="true" class="icon-36"></h3>
     <p>Once upon a time, long long ago, I ported PPSSPP to Windows Phone. Unfortunately I never got it to run well enough
         to be worth releasing, since JIT is fundamentally broken on Windows Phone (due to the lack of an API to invalidate the
         instruction cache), and the graphics driver was barely functional, causing many glitches.

--- a/pages/requestgold.hbs
+++ b/pages/requestgold.hbs
@@ -1,5 +1,4 @@
-{{> common_header this title="PPSSPP Cross License"
-description="Request PPSSPP Gold for Android, if you already have it on PC/Mac, here" noAds="true" }}
+{{> common_header this title="PPSSPP Cross License" description="Request PPSSPP Gold for Android here, if you already have it on PC/Mac" noAds="true" }}
 
 <div class="container">
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn build(opt: &Args) -> anyhow::Result<()> {
     for tmpl in templates {
         handlebars.register_template_file(tmpl, &format!("template/{tmpl}.hbs")).context("register_template")?;
     }
+    handlebars.register_template_file("buygold_inapp", "template/icons/buygold_inapp.hbs").context("register_template")?;
     handlebars.register_template_file("link_icon", "template/icons/link_icon.hbs").context("register_last_template")?;
 
     println!("PPSSPP website generator");

--- a/static/css/hamburger.css
+++ b/static/css/hamburger.css
@@ -13,37 +13,45 @@
     display: none;
 }
 
+.burger-sidebar img {
+    margin-right: 1ch;
+}
+
 .burger-menu {
     list-style: none;
     padding-left: 0px;
 }
 
-.burger-menu li {
+.burger-menu>li {
     border-bottom: 2px solid var(--color-gray-800);
     padding: 0px;
 }
 
-.burger-menu li:hover {
+.burger-menu>li:hover {
     background-color: var(--color-gray-700);
 }
 
-.burger-menu li a {
+.burger-menu>li a {
     padding: 8px 8px;
     display: block;
     color: var(--color-text);
 }
 
-.burger-menu li a:hover i.icon-ui {
+.burger-menu>li a:hover i.icon-ui {
     background-color: var(--color-text);
 }
 
-.burger-menu li a.switch-theme:hover {
+.burger-menu>li a.switch-theme:hover {
     cursor: pointer;
 }
 
-.burger-menu li #loginItem a,
-.burger-menu li #darkItem a {
+.burger-menu>li #loginItem a,
+.burger-menu>li #darkItem a {
     display: flex;
     flex-direction: row;
     align-items: center;
+}
+
+.burger-menu>li #darkItem i {
+    margin-right: 0.5ch;
 }

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -54,6 +54,7 @@ a:hover i.icon-ui {
 i.icon-ui-external {
     --icon-path: url(/static/img/icons/ui/external-link.svg);
     vertical-align: top;
+    margin-left: 0.5ch;
 }
 
 i.icon-ui-clock {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -130,3 +130,25 @@ footer {
   background-color: var(--color-header-footer);
   color: var(--color-text)
 }
+
+/*
+  These values work well for both inline code and blocks.
+  Highlight script changes them for clode blocks where necessary.
+*/
+code {
+  font-family: monospace;
+  font-size: 95%;
+  display: inline-block;
+  border-radius: 6px;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: var(--color-gray-800);
+  word-break: break-word;
+  text-align: left;
+}
+
+.inapp {
+  font-family: Roboto, sans-serif;
+  font-size: 110%;
+  font-weight: bold;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -148,7 +148,8 @@ code {
 }
 
 .inapp {
-  font-family: Roboto, sans-serif;
+  display: inline-block;
+  font-family: Roboto, DroidSans, sans-serif;
   font-size: 110%;
   font-weight: bold;
 }

--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -27,6 +27,10 @@
     color: var(--color-a-hover);
 }
 
+.top-nav img {
+    margin-right: 1ch;
+}
+
 .menu {
     display: flex;
     flex-direction: row;

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -64,6 +64,10 @@ img.prev-ver-item {
     align-items: center;
 }
 
+.button-contents img {
+    margin-right: 1ch;
+}
+
 .hero-button {
     box-shadow: 0 0 10px var(--shadow-color);
     margin: 14px 0px;

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -314,22 +314,6 @@ a.nav-tree-item.selected {
     display: none;
 }
 
-/*
-    These values work well for both inline code and blocks.
-    Highlight script changes them for clode blocks where necessary.
-*/
-code {
-    font-family: monospace;
-    font-size: 95%;
-    display: inline-block;
-    border-radius: 6px;
-    padding: .2em .4em;
-    margin: 0;
-    background-color: var(--color-gray-800);
-    word-break: break-word;
-    text-align: left;
-}
-
 .collapsible {
     background-color: var(--color-primary);
     color: var(--color-text-inverse);

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -195,7 +195,7 @@ src="/static/img/platform/ppsspp-icon-gold.png"
 {{#else}}
 src="/static/img/platform/ppsspp-icon.png"
 {{/if}}
-class="icon-24">&nbsp;{{it.name}}
+aria-hidden="true" class="icon-24">{{it.name}}
 {{#else}}
 Login
 {{/if}}
@@ -212,7 +212,7 @@ src="/static/img/platform/ppsspp-icon-gold.png"
 {{#else}}
 src="/static/img/platform/ppsspp-icon.png"
 {{/if}}
-class="icon-24">&nbsp;{{it.name}}
+aria-hidden="true" class="icon-24">{{it.name}}
 {{#else}}
 Login
 {{/if}}

--- a/template/blog_page.hbs
+++ b/template/blog_page.hbs
@@ -29,7 +29,7 @@
 
         {{{ contents }}}
 
-        {{> unit}}
+        {{> unit }}
 
         <div class="nav-link-container">
             {{ #if meta.prev }}

--- a/template/blog_tags.hbs
+++ b/template/blog_tags.hbs
@@ -1,5 +1,3 @@
-{{!-- tag listing --}}
-
 <h1>Article tags</h1>
 
 {{ #each tags }}

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -60,10 +60,10 @@
                         external}}{{> link_icon }}{{/if}}</a></li>
                 {{/each}}
                 <li>
-                    <a class="switch-theme" onclick="switchTheme()" style="display:inline"><i class="icon-ui icon-ui-moon"></i></a>
+                    <a class="switch-theme" onclick="switchTheme()"><i class="icon-ui icon-ui-moon"></i></a>
                 </li>
             </ul>
-            <div id="loginCorner" style="display:inline"><a href="/login">Login</a></div>
+            <div id="loginCorner"><a href="/login">Login</a></div>
         </nav>
 
         <section class="contents">

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -50,8 +50,8 @@
                 <div class='menu-button'></div>
             </div>
             <div class="top-nav-logo">
-                <a href="/" class="center-vertical"><img src="/static/img/platform/ppsspp-icon.png" alt="icon"
-                        class="icon-32">&nbsp;PPSSPP</a>
+                <a href="/" class="center-vertical"><img src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
+                        class="icon-32">PPSSPP</a>
             </div>
             <ul class="menu">
                 {{#each top_nav}}
@@ -60,7 +60,7 @@
                         external}}{{> link_icon }}{{/if}}</a></li>
                 {{/each}}
                 <li>
-                    <a class="switch-theme" onclick="switchTheme()"><i class="icon-ui icon-ui-moon"></i></a>
+                    <a class="switch-theme" onclick="switchTheme()"><i alt="Dark Mode" class="icon-ui icon-ui-moon"></i></a>
                 </li>
             </ul>
             <div id="loginCorner"><a href="/login">Login</a></div>
@@ -80,7 +80,7 @@
                     </li>
                     <li>
                         <a id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i class="icon-ui icon-ui-moon"></i>&nbsp;Dark Mode
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>Dark Mode
                         </a>
                     </li>
                 </ul>

--- a/template/icons/buygold_inapp.hbs
+++ b/template/icons/buygold_inapp.hbs
@@ -1,1 +1,1 @@
-"&NoBreak;<b class="inapp">Buy&nbsp;PPSSPP&nbsp;Gold&nbsp;<img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-24"></b>"
+<b class="inapp">Buy PPSSPP Gold <img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-24"></b>

--- a/template/icons/buygold_inapp.hbs
+++ b/template/icons/buygold_inapp.hbs
@@ -1,0 +1,1 @@
+"&NoBreak;<b class="inapp">Buy&nbsp;PPSSPP&nbsp;Gold&nbsp;<img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-24"></b>"

--- a/template/icons/buygold_inapp.hbs
+++ b/template/icons/buygold_inapp.hbs
@@ -1,1 +1,1 @@
-<b class="inapp">Buy PPSSPP Gold <img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-24"></b>
+<b class="inapp">Buy PPSSPP Gold <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24"></b>

--- a/template/icons/link_icon.hbs
+++ b/template/icons/link_icon.hbs
@@ -1,1 +1,1 @@
-&nbsp;<i class="icon-ui icon-ui-external" alt="external link"></i>
+<i class="icon-ui icon-ui-external" alt="external link"></i>

--- a/template/product_card.hbs
+++ b/template/product_card.hbs
@@ -9,8 +9,8 @@
             <button type="button" class="download-button button-block button-gold" data-fsc-item-path="{{ productId }}"
                 data-fsc-item-path-value="{{ productId }}" data-fsc-action="Reset,Add,Checkout">
                 <div class="button-contents">
-                    <img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-48">
-                    <span style="padding-left: 10px">&nbsp;Buy PPSSPP Gold</span>
+                    <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-48">
+                    Buy PPSSPP Gold
                 </div>
             </button>
         </div>

--- a/template/product_card.hbs
+++ b/template/product_card.hbs
@@ -8,9 +8,9 @@
             <p>{{ description }}<br /><span>{{ price }}</span></p>
             <button type="button" class="download-button button-block button-gold" data-fsc-item-path="{{ productId }}"
                 data-fsc-item-path-value="{{ productId }}" data-fsc-action="Reset,Add,Checkout">
-                <div style="display: flex; flex-direction: row; align-items: center;">
+                <div class="button-contents">
                     <img src="/static/img/platform/ppsspp-icon-gold.png" class="icon-48">
-                    <span style="paddingLeft: 10px">&nbsp;Buy PPSSPP Gold</span>
+                    <span style="padding-left: 10px">&nbsp;Buy PPSSPP Gold</span>
                 </div>
             </button>
         </div>


### PR DESCRIPTION
A bunch of smaller things I've had on my mind.

- replace the warning about Orphis' dev builds with the regular warning text inside the dev build alert (it's been a long time now)
- move `code` block formatting to `style.css` from `ui.css`
- an `inapp` class to emphasize buttons in the PPSSPP app (shame it can't be used in Markdown...)
- create a template for "Buy PPSSPP Gold" inapp button
- clean up some inline style attributes that practically do nothing
- remove some of the useless comments I mentioned in #61
- replace some `&nbsp;` characters with proper css margin
- clean up alt attributes of icons

Screenshot of "Buy PPSSPP Gold" template, also showcasing the `inapp` class:
![image](https://github.com/user-attachments/assets/1853723a-13a1-44fc-835b-e54c41c242a9)
