### PR TITLE
Bring back the Buy PPSSPP Gold on download.hbs

### DIFF
--- a/data/platform.json
+++ b/data/platform.json
@@ -141,8 +141,13 @@
         "title": "iOS",
         "platform_badge": "ios.svg",
         "platform_key": "ios",
-        "description": "PPSSPP for iOS is not officially supported but working builds can be found.",
         "downloads": [
+            {
+                "name": "Buy PPSSPP Gold",
+                "icon": "ppsspp-icon-gold.png",
+                "url": "/buygold_ios",
+                "gold": true
+            },
             {
                 "name": "PPSSPP for iOS",
                 "icon": "ppsspp-icon.png",

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -4,10 +4,10 @@
     <h1>Buy PPSSPP Gold {{ globals.app_version }}</h1>
 
     <div class="gold-only">
-        <h2>Gold already!</h2>
-        <p class="magenta">You are already a Gold user, are you looking for <a href="/download">the
-                downloads</a>?</p>
-        <p>Of course, feel free to purchase again if you'd like to support PPSSPP even more.</a>
+        <h2>Gold already!&nbsp;<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-36"></h2>
+        <div class="alert alert-warning">You are already a Gold user, are you looking for
+            <a href="/download">the downloads</a>?</div>
+        <p>Of course, feel free to purchase again if you'd like to support PPSSPP even more.</p>
     </div>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for Android&nbsp;<img src="/static/img/icons/android.svg"
@@ -31,13 +31,9 @@
         Gold for Windows/macOS&nbsp;<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-36">
             &nbsp;<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-36"/></h2>
 
-    <p></p>
-
     <p>Buy PPSSPP Gold to support the project! Choose your level of contribution:</p>
 
-    <div class="alert alert-hidden" id="fastspring-error-alert">
-
-    </div>
+    <div class="alert alert-hidden" id="fastspring-error-alert"></div>
 
     <div class="row" id="product-cards">
         {{> product_card title="Hangaround" description="A show of support." productId="ppsspp-gold-l1" }}


### PR DESCRIPTION
When you updated the json you outright removed the Buy Gold button under the iOS platform. This removes the hint of PPSSPP Gold existing for iOS when viewed from the Download page. So this PR brings that button back and links to `buygold_ios` for now.

![image](https://github.com/user-attachments/assets/0d0ad5fa-44e8-41fc-9eb0-cbc921dbc11a)

P.S.: I couldn't find references to `https://www.ppsspp.org/buygold_ios` in the app's source code, only `https://www.ppsspp.org/buygold.hbs`, so I couldn't find said link's context either.