### PR TITLE
Adjust top navigation bar responsive values

### DIFF
--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -61,6 +61,17 @@
     background-color: var(--color-a-hover);
 }
 
+.menu>li.external {
+    /* Hide external list items */
+    display: none;
+}
+
+@media (min-width: 1000px) {
+    .menu>li.external {
+        display: flex;
+    }
+}
+
 .menu-button-container {
     display: none;
     height: 100%;
@@ -101,34 +112,19 @@
     margin-top: 8px;
 }
 
-.menu .external {
-    display: none;
-}
-
-@media (min-width: 800px) {
-    .menu .external {
-        display: flex;
-    }
-}
-
 #loginCorner {
     display: flex;
     flex-direction: row;
     align-items: center;
 }
 
-@media (max-width: 600px) {
-
+@media (max-width: 850px) {
     /* Hide the login corner */
     #loginCorner {
         display: none;
     }
 
     .menu-button-container {
-        display: flex;
-    }
-
-    .menu .external {
         display: flex;
     }
 

--- a/template/common_footer.hbs
+++ b/template/common_footer.hbs
@@ -16,10 +16,9 @@
             <div class="col-4">
                 <h2>Community</h2>
                 <ul class="clean-list">
-                    <li><a href="https://discord.gg/5NJB6dD">Discord{{> link_icon }}</a>
-                    </li>
-                    <li><a href="https://x.com/PPSSPP_emu">PPSSPP on X{{> link_icon }}</a>
-                    </li>
+                    <li><a href="https://discord.gg/5NJB6dD">Discord{{> link_icon }}</a></li>
+                    <li><a href="https://forums.ppsspp.org/">Forums{{> link_icon }}</a></li>
+                    <li><a href="https://x.com/PPSSPP_emu">PPSSPP on X{{> link_icon }}</a></li>
                 </ul>
             </div>
             <div class="col-4">

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -62,9 +62,9 @@ Play multiplayer with your friends. Download for Android, Windows PC, macOS, iOS
             </div>
             <ul class="menu">
                 {{#each top_nav}}
-                <li><a href="{{url}}"
-                        class="{{#if selected}}selected{{/if}}{{#if external}} external{{/if}}">{{{title}}}{{#if
-                        external}}{{> link_icon }}{{/if}}</a></li>
+                <li {{#if external}}class="external"{{/if}}>
+                    <a href="{{url}}" {{#if selected}}class="selected"{{/if}}>{{{title}}}{{#if external}}{{> link_icon }}{{/if}}</a>
+                </li>
                 {{/each}}
                 <li>
                     <div class="switch-theme" onclick="switchTheme()">
@@ -80,9 +80,7 @@ Play multiplayer with your friends. Download for Android, Windows PC, macOS, iOS
                 {{!-- We repeat all the same stuff again, but add Login. Better than crazy CSS tricks... --}}
                 <ul class="burger-menu">
                     {{#each top_nav}}
-                    <li><a href="{{url}}"
-                            class="{{#if selected}}selected{{/if}}{{#if external}} external{{/if}}">{{{title}}}{{#if
-                            external}}{{> link_icon }}{{/if}}</a></li>
+                    <li><a href="{{url}}" {{#if selected}}class="selected"{{/if}}>{{{title}}}{{#if external}}{{> link_icon }}{{/if}}</a></li>
                     {{/each}}
                     <li>
                         <div id="loginItem"><a href="/login">Login</a></div>


### PR DESCRIPTION
Helps #78, but it's still not good for names even longer... Not sure whether we should close it.

Moving the external class from links to list items removes the unnecessary whitespace before the moon icon (see 2nd image of mentioned issue)

![image](https://github.com/user-attachments/assets/50391097-d5fc-4140-888f-4eadde9b9459)

As compensation for increasing the sizes, I've added the Forums link to the footer.