### PR TITLE
No longer display name in top-nav

### DIFF
--- a/static/css/hamburger.css
+++ b/static/css/hamburger.css
@@ -45,7 +45,6 @@
 
 .burger-menu>li .switch-theme {
     padding: 11px;
-    display: block;
 }
 
 .burger-menu>li .switch-theme:hover {
@@ -53,6 +52,9 @@
     cursor: pointer;
 }
 
-.burger-menu>li .switch-theme i.icon-ui {
-    margin-right: 0.5ch;
+.burger-menu>li #loginItem a,
+.burger-menu>li .switch-theme {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 }

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -63,6 +63,10 @@ a:hover i.icon-ui {
    background-color: var(--color-a-hover);
 }
 
+i.icon-left {
+    margin-right: 0.5ch;
+}
+
 i.icon-ui-external {
     --icon-path: url(/static/img/icons/ui/external-link.svg);
     vertical-align: top;

--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -67,7 +67,7 @@
     display: none;
 }
 
-@media (min-width: 1000px) {
+@media (min-width: 850px) {
     .menu>li.external {
         display: flex;
     }
@@ -119,7 +119,11 @@
     align-items: center;
 }
 
-@media (max-width: 850px) {
+#loginCorner i.icon-ui {
+    font-size: 24px;
+}
+
+@media (max-width: 699px) {
     /* Hide the login corner */
     #loginCorner {
         display: none;

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -123,7 +123,7 @@ const tmplUserInfo = `
 </p>
 <p>E-mail: {{it.email}}</p>
 {{ @if (it.goldUser) }}
-<p class="center-vertical">Gold status!<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24"></p>
+<p>Gold status!</p>
 {{ /if }}
 <p><a href="/changepassword">Change password</a></p>
 </div>
@@ -207,30 +207,17 @@ const tmplPlayCodes = `
 const tmplLoginCorner = `
 <a href='/login' class="center-vertical">
 {{@if(it.loggedIn)}}
-<img
-{{@if(it.goldUser)}}
-src="/static/img/platform/ppsspp-icon-gold.png"
-{{#else}}
-src="/static/img/platform/ppsspp-icon.png"
-{{/if}}
-aria-hidden="true" class="icon-24">{{it.name}}
+<i aria-label="Profile" class="icon-ui icon-ui-user"></i>
 {{#else}}
 Login
 {{/if}}
 </a>
 `;
 
-
 const tmplLoginItem = `
 <a href='/login'>
 {{@if(it.loggedIn)}}
-<img
-{{@if(it.goldUser)}}
-src="/static/img/platform/ppsspp-icon-gold.png"
-{{#else}}
-src="/static/img/platform/ppsspp-icon.png"
-{{/if}}
-aria-hidden="true" class="icon-24">{{it.name}}
+<i aria-hidden="true" class="icon-ui icon-ui-user"></i>{{it.name}}
 {{#else}}
 Login
 {{/if}}
@@ -254,22 +241,23 @@ async function applyDOMVisibility() {
     setDisplayMode("no-gold-only", g_userData.goldUser ? "none" : "block");
 
     // Update various textual fields if present on the page.
-    const loginName = document.getElementById("displayName");
-    if (loginName) {
-        loginName.innerHTML = "<a href='/login'>" + g_userData.name + "</a>";
-    }
-    const loginEmail = document.getElementById("displayEmail");
-    if (loginEmail) {
-        loginEmail.innerText = g_userData.email;
+    // Top navigation bar
+    const navbarIcon = document.getElementById("navbarIcon");
+    if (navbarIcon) {
+        navbarIcon.src = g_userData.goldUser ? "/static/img/platform/ppsspp-icon-gold.png" : "/static/img/platform/ppsspp-icon.png";
     }
     const loginCorner = document.getElementById("loginCorner");
     if (loginCorner) {
         loginCorner.innerHTML = Sqrl.render(tmplLoginCorner, g_userData);
     }
+
+    // Hamburger menu
     const loginItem = document.getElementById("loginItem");
     if (loginItem) {
         loginItem.innerHTML = Sqrl.render(tmplLoginItem, g_userData);
     }
+
+    // Login page
     const loginInfo = document.getElementById("loginInfo");
     if (loginInfo) {
         loginInfo.innerHTML = Sqrl.render(tmplUserInfo, g_userData);

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -60,7 +60,7 @@
                 <div class='menu-button'></div>
             </div>
             <div class="top-nav-logo">
-                <a href="/" class="center-vertical"><img src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
+                <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
                         class="icon-32">PPSSPP</a>
             </div>
             <ul class="menu">
@@ -90,7 +90,7 @@
                     </li>
                     <li>
                         <div id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>Switch Theme
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon icon-left"></i>Switch Theme
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
Fixes #78 with the method I've suggested.

The caveat is that the PPSSPP icon in the top left corner doesn't get replaced with the Gold icon until the script is run.
(So just like the contents of `#loginCorner` itself.)

The screenshots were taken while being logged in. There's nothing different compared to current look while being logged out.
![image](https://github.com/user-attachments/assets/5fb79db0-74e4-40f5-911e-625e2ee9f0a1)
![image](https://github.com/user-attachments/assets/53d4df29-b419-4a07-a48c-91e167e847f3)
![image](https://github.com/user-attachments/assets/558fb2c3-66c3-4532-b8e2-4eebe005c31e)
![image](https://github.com/user-attachments/assets/c5afc026-4867-4814-b1cd-cc075e58dad2)
