### PR TITLE
Make meta description more baity

### DIFF
--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -6,10 +6,8 @@
     <title>{{title}} - PPSSPP</title>
 
     <meta charset="UTF-8"/>
-    <meta name="description" content="PPSSPP is a free and open-source PSP emulator with a focus on performance and portability.
-Play PSP games on your phone in high resolution with improved graphics.
-Continue from your PSP saves. Save and restore game state anytime.
-Play multiplayer with your friends. Download for Android, Windows PC, macOS, iOS, Linux and more."/>
+    <meta name="description" content="Play PSP games in HD on Android, iOS, Windows, macOS, and more with enhanced graphics
+and customizable controls! Free and open source. Download now!"/>
     <meta name="keywords" content="PSP, emulator">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>


### PR DESCRIPTION
Originally I rewrote it to the following:
```
Play your PSP games on the go in HD! PPSSPP is highly performant and portable. Download now for Android, iOS, Windows, macOS and more! Free and open source, anybody can contribute. Enhance your experience with improved graphics, savestates and fast-forward! Customizable controller and touch support. Play PSP multiplayer with your friends!
```

And then asked AI to shorten it.

Ideally we'd want it to be customizable for each page. I was about to look into before I got distracted by other things.