### PR TITLE
Reorder game lists in docs alphabetically

### DIFF
--- a/docs/development/ppsspp-internals/atrac.md
+++ b/docs/development/ppsspp-internals/atrac.md
@@ -17,7 +17,7 @@ We first started by using an external library, which required buffering up audio
 When ffmpeg finally added support, we never switched over to using the internal buffering.
 Mostly because I didn't realize back then that the entire context is conveniently exposed (see below).
 
-But now, finally, we're getting accurate emulation of the buffering, which is critical for some games that use the library in slightly unusual ways, such as Flatout.
+But now, finally, we're getting accurate emulation of the buffering, which is critical for some games that use the library in slightly unusual ways, such as FlatOut.
 
 ## Loading the sceAtrac library
 
@@ -29,23 +29,23 @@ However, it wouldn't work with the sceSas integration, and also would be limited
 
 ### Games that use sceUtilityLoadModule:
 
-* Wipeout Pulse
-* Many more....
+* WipEout Pulse
+* many more....
 
 ### Games that use sceUtilityLoadAvModule
 
 This was previously not hooked up properly. Worked anyway because our sceAtrac impl doesn't require initialization.
 
 * MotoGP
-* Many more....
+* many more....
 
 ### Games that supply their own:
 
 * Burnout Legends (1.1)
-* Gitaroo Man (1.2)
 * Daxter (1.3)
-* Flatout (1.5)
-* Many more....
+* FlatOut (1.5)
+* Gitaroo Man (1.2)
+* many more....
 
 ### Different versions of the library
 
@@ -72,9 +72,9 @@ Most games only use Atrac3+ audio, but a few games (especially early games and P
 
 ### Games using Atrac3 (not plus)
 
-* Patapon
 * Mega Man Powered Up
-* A lot more...
+* Patapon
+* a lot more...
 
 ## Coordinate systems for offsets
 
@@ -261,10 +261,10 @@ However, if you supply less data than asked, you can still create split packets 
 
 ### All-data-loaded (looping or not)
 
-- MotoGP (menu music with specified loop). Simple repeated calls to sceAtracDecodeData
+- 3rd Birthday (also uses AT3 in addition to AT3+)
 - Archer MacLean's Mercury (in-game, not menu)
 - Crisis Core
-- 3rd Birthday (also uses AT3 in addition to AT3+)
+- MotoGP (menu music with specified loop). Simple repeated calls to sceAtracDecodeData
 
 ### Streaming
 
@@ -277,13 +277,13 @@ However, if you supply less data than asked, you can still create split packets 
   - Suicide Barbie (simple stream, no loop)
 
 - Others
-  - Bleach
-  - God of War: Chains of Olympus
   - Ape Academy 2 (bufsize 8192)
+  - Bleach
+  - FlatOut (tricky! needs investigation)
+  - God of War: Chains of Olympus
   - Half Minute Hero (bufsize 65536)
-  - Flatout (tricky! needs investigation)
-  - Outrun 2006
-  - Many, many more...
+  - OutRun 2006
+  - many, many more...
 
 ## Streaming with looping
 
@@ -301,9 +301,9 @@ In this case, the game just submits packets to decode to the decoder, sceAtrac d
 
 As mentioned before, Atrac3+ streams are usually stored in RIFF WAVE containers, but there's also AA3, which is one possible extension for "Sony OpenMG Music". This is used by very, very few games though:
 
-* Mod Nation Racers
 * Beats
-* A few more, can't find the list anymore
+* Mod Nation Racers
+* a few more, can't find the list anymore
 
 ### sceSas integration
 
@@ -317,17 +317,17 @@ Note: It seems the buffer you feed it from using Concatenate.. has to be double-
 
 This is not that common, known games that are using it:
 
+- L.A Gridlock (Minis)
+- Mad Blocker Alpha (Minis)
 - Sol Trigger
-- Mad Blocker Alpha (mini)
-- L.A Gridlock (mini)
-- Actually, a bunch more according to reports:
+- actually, a bunch more according to reports:
   - https://report.ppsspp.org/logs/kind/193  SetVoice
   - https://report.ppsspp.org/logs/kind/197  Concatenate
 
 ### Not using Atrac3+, but instead sequenced MIDI music
 
-- Bust-a-Move Deluxe
 - Breath of Fire III
+- Bust-a-Move Deluxe
 - Every Extend Extra
 - ... quite a few more, especially PSX ports.
 
@@ -382,7 +382,7 @@ Uses an unusually small buffer. We match this in our stream.prx test.
 0=sceAtracDecodeData(0, 092d3ad0, 09fdea70[00000800], 09fdea74[00000000], 09fdea78[85])
 ```
 
-### Flatout
+### FlatOut
 
 Uses the FMOD library.
 

--- a/docs/development/ppsspp-internals/feature-map.md
+++ b/docs/development/ppsspp-internals/feature-map.md
@@ -4,25 +4,26 @@ This is a very incomplete list of games to test with if you want to debug a spec
 
 ## OS and hardware features
 
-### OSK (On-screen keyboard)
+### OSK (on-screen keyboard)
 
 - MotoGP (single-language)
 - PES 2013 (single-language)
-- Many more
+- many more
 
 ### Microphone (hardware expansion)
 
-- Invizimals
-- Infected (Shouting into the mic pushes enemies back)
-- Rock Band Unplugged
+- Beaterator
 - DJ Max Fever
-- Talkman
 - Go Explore
+- Infected (shouting into the mic pushes enemies back)
+- Invizimals
+- Rock Band Unplugged
+- Talkman
 
 ### Camera (hardware expansion)
 
-- Invizimals
 - EyePet Adventures
+- Invizimals
 
 ### GPS
 
@@ -33,72 +34,71 @@ This is a very incomplete list of games to test with if you want to debug a spec
 ### Spline/Bezier patches
 
 - Loco Roco (all games and variants)
+- Namco Museum: Battle Collection (Pac-Man, more). This still exhibits a small bug (black patch on top of the ghosts)
 - Pursuit Force (both games)
 - Puzzle Bobble Pocket (completely unnecessary! Just used for rotating sprites)
-- Namco Museum: Battle Collection (Pacman, more). This still exhibits a small bug (black patch on top of the ghosts)
-- One of the snowboarding games
+- one of the snowboarding games
 
 ### Vertex culling / guardband
 
-- DTM Race Driver
-- Race Driver 2006
-- TOCA
+- TOCA Race Driver 2 / DTM Race Driver 2 / V8 Supercars Australia 2 / Race Driver 2006
+- TOCA Race Driver 3 Challenge / DTM Race Driver 3 Challenge / V8 Supercars Australia 3: Shootout
 
 ### Vertex skinning/bones
 
 - Crisis Core
-- Tekken 6
-- Tekken 5
 - God of War (both games)
-- Many, many more.
+- Tekken 5
+- Tekken 6
+- many, many more.
 
 ### Vertex morphing
 
-- Outrun 2006 (flame rings in 4th level on the left, 4 morph weights IIRC)
 - Motorstorm (vehicles, 1-2 weights only)
+- OutRun 2006 (flame rings in 4th level on the left, 4 morph weights IIRC)
 
 ### Depth buffer reads from the CPU
 
-- Wipeout (sun lens flare). Multiple reads per frame to get an average.
-- Syphon Filter (light halos (lots per frame!))
 - Midnight Club: LA (sun lens flare)
-- A few more
+- Syphon Filter (light halos (lots per frame!))
+- WipEout (sun lens flare). Multiple reads per frame to get an average.
+- a few more
 
 ### Direct color buffer reads from the CPU
 
-- Motorstorm (light adaptation)
-- Dangan Ronpa, Dangan Ronpa 2 (renders a separate mini buffer to select clues, people)
 - Coded Arms: Contagion (reads a single pixel from the alpha/stencil channel to identify enemies to lock-on)
-- A few more
+- Dangan Ronpa, Dangan Ronpa 2 (renders a separate mini buffer to select clues, people)
+- Motorstorm (light adaptation)
+- a few more
 
 ### Color buffer format aliasing
 
-- Outrun 2
+- Cars Race-o-rama
+- OutRun 2
 - Split/Second
 - Spongebob
-- Cars Race-o-rama
 
 ### Depth buffer manual swizzling through geometry
 
 This is a mistake that a few games have made - the PSP has hardware to swizzle depth buffers to linear, but instead they use triangles. This applies to the particle effects in these games
 
-- Ratchet & Clank (both games)
 - Jak & Daxter
+- Ratchet & Clank (both games)
 
 ### Tricks requiring dual source blending
 
-- Wipeout Pure (bloom effect)
-- Armored Core 3 (issue #11430)
-- Lens flares in Ridge Racer
+- Armored Core 3 (issue [#11430])
+- Ridge Racer (lens flares)
+- WipEout Pure (bloom effect)
 
 ### Intra-buffer block copies
 
-- Tales of Phantasia X/Cross Edition (included as a retro game in Tales of Phantasia: Narikiri Dungeon X). See issue #21098
+- Tales of Phantasia X/Cross Edition (included as a retro game in Tales of Phantasia: Narikiri Dungeon X), see issue [#21098]
 
 ### Block copies to RAM, later used as texture
 
-- Digimon
 - Burnout Legends (sun lens flare)
+- Digimon
 - Tales of Phantasia X
 
 ### Memcpy framebuffer download/upload
@@ -111,4 +111,4 @@ This is a mistake that a few games have made - the PSP has hardware to swizzle d
 
 ### Persistent render targets
 
-- Mahjong Artifacts (mini) relies on render targets sticking around.
+- Mahjong Artifacts (Minis) relies on render targets sticking around.

--- a/docs/development/ppsspp-internals/font.md
+++ b/docs/development/ppsspp-internals/font.md
@@ -4,7 +4,7 @@ Similar to the various upper level media decoders, sceFont is a user library tha
 
 There seem to be several different versions though, some that require functionality that we don't have yet, so that'll need to be solved somehow.
 
-Some Chinese translations use custom versions of sceFont, see issue #19111. Loading these can fix them in PPSSPP.
+Some Chinese translations use custom versions of sceFont, see issue [#19111]. Loading these can fix them in PPSSPP.
 
 ## sceReg
 
@@ -12,15 +12,15 @@ sceFont loads font configurations from the PSP system registry using sceReg.
 
 ## Games using sceFont
 
-* (Chinese translation of) Haruhi Suzumiya no Tsuisou (ULJS00371)
-* Shinobido Tales of The Ninja
-* Earth Saver Plus
 * BlazBlue Continuum Shift
-* Qix++
-* Lumines 2
+* Dragon Ball Z: Shin Budokai 2
+* Earth Saver Plus
 * Hammerin' Hero
+* (Chinese translation of) Haruhi Suzumiya no Tsuisou (ULJS00371)
+* Lumines 2
+* Monster Hunter Series
+* Qix++
+* Shinobido Tales of The Ninja
 * Tantei Jinguji Saburo Hai to Diamond
 * Valkyria Chronicles
-* Monster Hunter Series
-* Dragon Ball ShinBudokai 2
-* Many more...
+* many more...

--- a/docs/development/ppsspp-internals/mp3.md
+++ b/docs/development/ppsspp-internals/mp3.md
@@ -2,7 +2,7 @@
 
 sceMp3 acts as an MP3 parser and wrapper around sceAudiocodec's MP3 decoding ability, adding lots of utility functions and helpers to make streaming from disk easy.
 
-Here's a typical calling sequence (from Wipeout Pulse):
+Here's a typical calling sequence (from WipEout Pulse):
 
 ```
 0=sceMp3InitResource()

--- a/docs/development/ppsspp-internals/mpeg.md
+++ b/docs/development/ppsspp-internals/mpeg.md
@@ -28,11 +28,11 @@ scePsmf:
 
   * Jackass
   * LocoRoco 2
-  * Socom Fireteam Bravo 3 (#18094)
-  * PaRappa the Rapper
   * Machi: Unmei no Kousaten (ULJM05111)
+  * PaRappa the Rapper
+  * Socom Fireteam Bravo 3 ([#18094])
 
 sceMpeg:
-  * Grand Theft Auto: Vice City Stories (initial logos)
   * Crisis Core
-  * Wipeout Pulse
+  * Grand Theft Auto: Vice City Stories (initial logos)
+  * WipEout Pulse

--- a/docs/multiplayer/infrastructure-servers.md
+++ b/docs/multiplayer/infrastructure-servers.md
@@ -30,7 +30,7 @@ The [Antigravity Racing Foundation](https://agracingfoundation.org/)!
 
 DNS: 147.135.213.57
 
-A project to keep Wipeout Pulse, Wipeout 2048 and Wipeout HD multiplayer alive by the use of custom infrastructure servers. Made for real PSPs/PS3s, but works with some custom versions of PPSSPP.
+A project to keep WipEout Pulse, WipEout 2048 and WipEout HD multiplayer alive by the use of custom infrastructure servers. Made for real PSPs/PS3s, but works with some custom versions of PPSSPP.
 
 Motorstorm: Artic Edge also works on this server.
 
@@ -50,11 +50,11 @@ More documentation will be added later here, in the meantime here's a list of pr
 * [PSORG](https://github.com/PSOnlineReturnalGaming)
 * LittleBigRefresh
 * PS3 Reborn (Discord group)
-* Outrun2006 Tweaks
+* OutRun2006Tweaks
 
 ## Game compatibility list
 
-### Wipeout Pulse
+### WipEout Pulse
 
 Infrastructure mode works great in this game, except that for some reason, opponent ship textures are wrong or corrupted. This is not a rendering issue, we are not sure why this happens.
 

--- a/docs/psp-hardware/gpu/ge-overview.md
+++ b/docs/psp-hardware/gpu/ge-overview.md
@@ -28,7 +28,7 @@ Color masking is not just per channel like on PC, you can set a full bitmask and
 
 A scissor rectangle is supported, and is the only thing that limits the bounds of rendering (the viewport parameters do not specify a rectangle).
 
-It has a normal set of blend factors and blend modes, with some additions, that are somewhat tricky to emulate - 2xSRC, 2xDST, their negations, and the special blend op ABSDIFF which does what you'd guess. This one is pretty rare but is used for example for the cartoon rendering effect in Dragon Ball Z - Tenkaichi Tag Team.
+It has a normal set of blend factors and blend modes, with some additions, that are somewhat tricky to emulate - 2xSRC, 2xDST, their negations, and the special blend op ABSDIFF which does what you'd guess. This one is pretty rare but is used for example for the cartoon rendering effect in Dragon Ball Z: Tenkaichi Tag Team.
 
 Stencil buffers are not stored separately, and are not interleaved with the depth buffer like on PC. Instead, the color alpha channel serves double duty as both stencil and alpha data. This means that if you specify that your framebuffer has the format R5G5B5A1, there really is only 1 bit of stencil, while with R4G4B4A4 you effectively have a 4-bit stencil buffer and with R8G8B8A8 your stencil buffer is the full 8 bits wide. And if you render using R5G6B5 format, there simply is no stencil buffer available.
 

--- a/docs/reference/ios-support.md
+++ b/docs/reference/ios-support.md
@@ -31,13 +31,9 @@ Connect your device via USB to a Mac and use Finder to copy over files directly 
 
 If you don't have a Mac, use a Windows device and install [Apple Devices App](https://apps.microsoft.com/detail/9np83lwlpz9k).
 
-From PPSSPP 1.20, you can also click the Upload Files button and follow the instructions, to transfer files from another device or computer on the same wifi network.
+From PPSSPP 1.20, you can also click the Upload Files icon on the <b class="inapp">Games</b> tab and follow the instructions, to transfer files from another device or computer on the same WiFi network.
 
 ## Missing and upcoming features
-
-### Planned features
-
-* Device rotation is coming in 1.20.
 
 ### Missing features
 
@@ -51,4 +47,5 @@ The iOS build is missing a few features:
 These have been fixed:
 
 * UI keyboard input (now works, so RetroAchivement login works too)
-* Background image replacement (the easy way) (1.19).
+* Background image replacement (the easy way) (1.19)
+* Device rotation (1.20)

--- a/docs/troubleshooting/gettings-logs.md
+++ b/docs/troubleshooting/gettings-logs.md
@@ -4,7 +4,7 @@ Getting logs of crashes can make fixing them much easier.
 
 ## Getting ADB logs on Android
 
-This is the traditional way. Maybe there's some newfangled wifi way, I don't know :)
+This is the traditional way. Maybe there's some newfangled WiFi way, I don't know :)
 
 * Install the `adb` command line tool on your PC or Mac. There are two ways:
   1. Just install the [platform tools](https://developer.android.com/tools/releases/platform-tools) somewhere, which should include `adb.exe`.


### PR DESCRIPTION
Came here to add Beaterator to the list of microphone games, ended up doing a batch of list ordering and capitalization.
Very minor update to iOS support doc page too.