### PR TITLE
Make hamburger menu bigger

### DIFF
--- a/static/css/hamburger.css
+++ b/static/css/hamburger.css
@@ -25,6 +25,8 @@
 .burger-menu>li {
     border-bottom: 2px solid var(--color-gray-800);
     padding: 0px;
+    font-size: 14pt;
+    /*text-align: center;*/
 }
 
 .burger-menu>li:hover {
@@ -32,7 +34,7 @@
 }
 
 .burger-menu>li a {
-    padding: 8px;
+    padding: 11px;
     display: block;
     color: var(--color-text);
 }
@@ -42,7 +44,8 @@
 }
 
 .burger-menu>li .switch-theme {
-    padding: 8px;
+    padding: 11px;
+    display: block;
 }
 
 .burger-menu>li .switch-theme:hover {
@@ -50,13 +53,6 @@
     cursor: pointer;
 }
 
-.burger-menu>li #loginItem a,
-.burger-menu>li #darkItem {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.burger-menu>li #darkItem i.icon-ui {
+.burger-menu>li .switch-theme i.icon-ui {
     margin-right: 0.5ch;
 }

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -84,7 +84,7 @@
                     </li>
                     <li>
                         <div id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>Dark Mode
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>Switch Theme
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
The hamburger menu is pretty awkward to use on touch screen due to how small the menu items are.

This change helps with this issue by increasing the font size and padding.

Not as fancy as the redesign proposal in #76 , but it works.

Also removes flex for the last 2 items, can't figure out their purpose.

### Screenshots
All in 420x600 px.

Current:
<img width="420" height="600" alt="burger_current" src="https://github.com/user-attachments/assets/3170344d-6bb9-4e97-9a3c-db08ac1a09a2" />

With this PR:
<img width="420" height="600" alt="burger_thischange" src="https://github.com/user-attachments/assets/e3e7ca73-15c9-4151-97f7-21e5c5c3d6bb" />

### Some variations to consider
- centered text
<img width="420" height="600" alt="burger_variation_centered" src="https://github.com/user-attachments/assets/42499b19-1361-4905-aa3a-5646468a9752" />

- wider menu (75%)
<img width="420" height="600" alt="burger_variation_wider" src="https://github.com/user-attachments/assets/3e885d0e-5d66-4103-8497-190adebdaf94" />

- full-width menu (100%)
<img width="420" height="600" alt="burger_variation_fullwidth" src="https://github.com/user-attachments/assets/ca6b851d-c3d0-4a33-8550-55a8a833c29d" />
