### PR TITLE
More gold related prettifications

### DIFF
--- a/docs/reference/whygold.md
+++ b/docs/reference/whygold.md
@@ -1,4 +1,4 @@
-# PPSSPP Gold - the what and why
+# PPSSPP Gold – the what and why
 
 ## Why buy PPSSPP Gold?
 
@@ -11,7 +11,7 @@ PPSSPP and PPSSPP Gold have everything you'd want in a PSP emulator:
 
 PPSSPP Gold also:
 
-<img src="/static/img/platform/ppsspp-icon-gold.png" alt="UWP icon" class="icon-96 icon-right">
+<img src="/static/img/platform/ppsspp-icon-gold.png" alt="PPSSPP Gold icon" class="icon-96 icon-right">
 
 * Makes you feel good.
 * Has a fancy golden icon you can show off to your friends.
@@ -29,6 +29,18 @@ More platforms are planned to be added in the future, but as these are by far th
 
 Whether you own PPSSPP Gold for one of those platforms or not, feel free to use the free version on any platforms you have, as much as you want.
 
-## Why do I need to enter my phone number when making a purchase of the PC/Mac versions?
+## Why do I need to enter my phone number when making a purchase of the Windows/macOS versions?
 
-The payment provider uses the phone number in its algorithms to prevent credit card fraud. It is not actually used - you will not get calls from anyone and it's not stored.
+The payment provider uses the phone number in its algorithms to prevent credit card fraud.
+It is not actually used - you will not get calls from anyone and it's not stored.
+
+## I have purchased PPSSPP Gold for another platform before. Do I need to buy it again?
+
+If you have previously purchased PPSSPP Gold, you can [request a license](/requestgold) for Android, Windows and macOS.
+
+## Can I make a repeated purchase to support the project even more?
+
+If you have already bought PPSSPP Gold and want to support the development even more, you can always [make another purchase](/buygold)
+for Windows/macOS or check it out on another platform.
+
+Thank you for your repeated contribution!

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -15,15 +15,14 @@
     <a href="https://play.google.com/store/apps/details?id=org.ppsspp.ppssppgold"
         class="download-button button-gold button-block">
         <div class="button-contents"><img src="/static/img/platform/googleplay-badge.svg"
-                alt="Get it on Google Play" class="badge"/>Click to get PPSSPP Gold from Google Play!</div>
+                alt="Get it on Google Play" class="badge"/>Tap here to get PPSSPP Gold from Google Play!</div>
     </a>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS<img src="/static/img/icons/ios.svg"
             aria-hidden="true" class="icon-36"></h2>
 
-    <p>Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app, so just
-        <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903">download that</a>
-        and click the {{> buygold_inapp }} button!
+    <p>Starting from 1.19, <a href="/buygold_ios">PPSSPP Gold for iOS</a> is an in-app purchase in the regular PPSSPP app,
+        so just download that and click the {{> buygold_inapp }} button!
     </p>
 
     <h2 class="center-vertical">Buy PPSSPP

--- a/pages/buygold_ios.hbs
+++ b/pages/buygold_ios.hbs
@@ -2,29 +2,33 @@
 
 <div class="container">
 
-<h1>PPSSPP Gold for iOS</h1>
+    <h1>PPSSPP Gold for iOS</h1>
 
-<h2>How to buy PPSSPP Gold for iOS</h2>
+    <h2 class="center-vertical">How to buy PPSSPP Gold for iOS<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-36"></h2>
 
-<p>Download the regular version here, if you don't already have it:</p>
+    <p>Download the regular version here, if you don't already have it:</p>
 
-<p><a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903"><img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-36">&nbsp;Download PPSSPP on the App Store</a></p>
+    <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903" class="download-button button-block">
+        <div class="button-contents"><img src="/static/img/platform/appstore-badge.svg"
+                alt="Download on the App Store" class="badge"/>Tap here to download PPSSPP on the App Store!</div>
+    </a>
 
-<p>Then start it up and click the {{> buygold_inapp }} button in the app!</p>
+    <p>Then start it up and click the {{> buygold_inapp }} button in the app!</p>
 
-<p>For other platforms, <a href="/buygold">see here</a>.</p>
+    <p>For other platforms, <a href="/buygold">see here</a>.</p>
 
-<h2>Why buy PPSSPP Gold?</h2>
+    <h2>Why buy PPSSPP Gold?</h2>
 
-<p>PPSSPP Gold is the best way to support the development of PPSSPP, the leading PSP emulator for iOS and other platforms.</p>
+    <p>PPSSPP Gold is the best way to support the development of PPSSPP, the leading PSP emulator for iOS and other platforms.</p>
 
-<p>You get a nice golden icon, but otherwise it's the same as the regular version.</p>
+    <p>You get a nice golden icon, but otherwise it's the same as the regular version.
+        To learn more, <a href="/docs/reference/whygold">read here</a>.</p>
 
-<p>NOTE: Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app.</p>
+    <div class="alert alert-info">NOTE: Starting from 1.19, PPSSPP Gold for iOS is an in-app purchase in the regular PPSSPP app.</div>
 
-<h2>Did you previously own the separate Gold app for iOS?</h2>
+    <h2>Did you previously own the separate Gold app for iOS?</h2>
 
-<p>Unfortunately there's currently no way to transfer your purchase. I'm working on finding a way.</p>
+    <p>Unfortunately there's currently no way to transfer your purchase. I'm working on finding a way.</p>
 
 </div>
 

--- a/pages/requestgold.hbs
+++ b/pages/requestgold.hbs
@@ -2,9 +2,9 @@
 
 <div class="container">
 
-    <h1>Request Google Play promo code</h1>
-
     <div class="gold-only">
+        <h1>Request Google Play promo code</h1>
+
         <p>Since you already have PPSSPP Gold for Windows and macOS, you are eligible to request one Google Play promo
             code, which can be redeemed for PPSSPP Gold for Android free on any Google Play account.</p>
 
@@ -35,10 +35,11 @@
         <h1>PPSSPP Gold &ndash; Cross License</h1>
         <h3>Do you have PPSSPP Gold for Windows/macOS, but want it for Android?</h3>
         <p>If so, just <a href="/login?Forward=requestgold">login here</a> and follow the instructions!</p>
-        <h3>Do you have PPSSPP Gold for Android or iOS, but want it for Windows?</h3>
-        <p>Then please send an e-mail to <strong>hrydgard+ppssppgold@gmail.com</strong>, attaching your Google Play receipt. I try to
-            handle all requests within 72 hours, often faster.</p>
+        <h3>Do you have PPSSPP Gold for Android or iOS, but want it for Windows/macOS?</h3>
+        <p>Then please send an e-mail to <a href="mailto:hrydgard+ppsspp@gmail.com">hrydgard+ppssppgold@gmail.com</a>,
+            attaching your Google Play receipt. I try to handle all requests within 72 hours, often faster.</p>
     </div>
+
 </div>
 
 {{> common_footer this }}


### PR DESCRIPTION
- Expand the PPSSPP Gold reference page with more information. (Also fix the image alt.)
- Fix a header and make the e-mail address a link on the Request Gold page.
- Prettify the `buygold_ios` page.
- From the `buygold` page, link iOS users to the `buygold_ios` page instead of directly to the App Store.

<img width="960" height="708" alt="image" src="https://github.com/user-attachments/assets/4068cf9c-c6bd-4ee9-9e45-eb01c6402247" />
