### PR TITLE
Add intro paragraphs for settings + link to dev tools

### DIFF
--- a/docs/settings/audio.md
+++ b/docs/settings/audio.md
@@ -4,6 +4,8 @@ position: 3
 
 # Audio Settings
 
+Here are several audio-related PPSSPP settings.
+
 ## Audio playback
 
 ### Playback mode

--- a/docs/settings/recommended.md
+++ b/docs/settings/recommended.md
@@ -4,6 +4,8 @@ position: 7
 
 # Recommended settings
 
+The following setup is expected to be optimal for most players.
+
 ## High-end hardware
 
 If you have a powerful device, to get the most out of your games, in Graphics settings:

--- a/docs/settings/system.md
+++ b/docs/settings/system.md
@@ -4,6 +4,8 @@ position: 6
 
 # System
 
+Here are the generic system settings for PPSSPP, including the user interface configuration, savestate settings, etc.
+
 ## UI
 
 ### Language

--- a/docs/settings/tools.md
+++ b/docs/settings/tools.md
@@ -3,6 +3,8 @@ position: 5
 ---
 # Tools
 
+The Tools section contains miscellaneous utilities such as the Savedata manager or the RetroAchievements intergration.
+
 ## RetroAchievements
 
 Lets you log in and configure RetroAchievements. See [this page](/docs/reference/retro-achievements) for more information.
@@ -17,7 +19,7 @@ Shows device-related information such as the system specs, OpenGL and Vulkan ext
 
 ## Developer tools
 
-A large amount of obscure settings and test screens that have been added over the years as needed to help development.
+A large amount of obscure settings and test screens that have been added over the years as needed to help development. Some of them are documented [here](/docs/development/developer-tools).
 
 ## Remote disc streaming
 


### PR DESCRIPTION
First of all, some of the previews were wrong, because the website apparently picks the first non-header text and renders it here.
<img width="891" height="154" alt="image" src="https://github.com/user-attachments/assets/ba7ca5b9-776c-487d-8f40-bd7f21b22a63" />
Please tell me if any of the new descriptions could be improved. Or, ig, we can fix it later. I'm just filling in the emptiness.

Second of all, I added a link from Tools to Development/developer-tools.