### PR TITLE
Do away with XHTML-style self-closing tags

### DIFF
--- a/blog/2024-11-26-stuck-in-app-store-review.md
+++ b/blog/2024-11-26-stuck-in-app-store-review.md
@@ -33,7 +33,7 @@ For some time now, I have simply not been able to update the paid iOS version on
 
 Below is an authentic conversation with App Store Review. This is the second conversation, I previously had a much longer one, but it disappeared when I submitted a new build. The arguments were the same, just more rounds of back-and-forth.
 
-<hr/>
+<hr>
 
 ### Apple App Store Rejection, initial message
 
@@ -126,7 +126,7 @@ Learn more about intellectual property requirements in [guideline 5.2.2](https:/
 - Provide feedback on this message and your review experience by [completing a short survey](https://essentials.applesurveys.com/jfe/form/SV_esVePfih7uqt4NM?taskid=2ce1ec41-879a-48ff-8f12-4018e7b106eb&campaignid=0001).
 
 </i>
-<hr/>
+<hr>
 
 ### My initial response
 
@@ -150,7 +150,7 @@ I am the original author of this app. It is not spam, it's just the paid version
 
 There are no such files. If there's a file you have a complaint about. PLEASE LET ME KNOW EXACTLY WHICH ONE. The filename please.
 
-<hr/>
+<hr>
 
 ### Apple App Store Reply
 
@@ -174,7 +174,7 @@ App Review
 
 </i>
 
-<hr/>
+<hr>
 
 ### My second response
 
@@ -193,7 +193,7 @@ This app is serious software and is one of the most popular retro game console e
 
 So please, consider the facts above.
 
-<hr/>
+<hr>
 
 ### Apple App Store Reply #2
 
@@ -219,7 +219,7 @@ App Review
 
 </i>
 
-<hr/>
+<hr>
 
 ### Conclusion
 

--- a/docs/development/porting.md
+++ b/docs/development/porting.md
@@ -13,7 +13,7 @@ Here's an incomplete list of platforms that PPSSPP could or could not be ported 
 | Linux | Done | x86&#x2011;32/&NoBreak;64, ARM32/&NoBreak;64, LoongArch64, RISC&#x2011;V64 |
 | macOS | Done | Limited native UI |
 | iOS | Done | JIT works but not on the App Store builds. |
-| Windows UWP,<br />Xbox Series X\|&NoBreak;S,<br />Xbox One,<br />Windows 10&nbsp;Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_isa] |
+| Windows UWP,<br>Xbox Series X\|&NoBreak;S,<br>Xbox One,<br>Windows 10&nbsp;Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_isa] |
 | Nintendo Switch | Done | Homebrew enabled consoles only. |
 | Raspberry Pi | Done | R4+ recommended |
 

--- a/docs/reference/custom-background-music.md
+++ b/docs/reference/custom-background-music.md
@@ -95,17 +95,17 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
     </thead>
     <tbody>
         <tr>
-            <td>Beats,<br />Shouten Beat</td>
-            <td><code>ms:/PSP/MUSIC</code>,<br /><code>ms:/MUSIC</code>,<br /><code>ms:/MP3</code></td>
+            <td>Beats,<br>Shouten Beat</td>
+            <td><code>ms:/PSP/MUSIC</code>,<br><code>ms:/MUSIC</code>,<br><code>ms:/MP3</code></td>
             <td><ul>
                 <li>&#x26A0;&#xFE0F;&nbsp;see issue <a href="https://github.com/hrydgard/ppsspp/issues/14812">#14812</a></li>
                 <li>subfolders supported</li>
-                <li>also looks for ATRAC files<br /><small>(see ATRAC section for details)</small></li>
+                <li>also looks for ATRAC files<br><small>(see ATRAC section for details)</small></li>
             </ul></td>
         </tr>
         <tr>
-            <td>Crazy Taxi: Fare Wars,<br />Crazy Taxi: Double Punch</td>
-            <td><small>primary:</small><code>ms:/MUSIC/CRAZYTAXI</code><br /><small>fallback:</small><code>ms:/MUSIC</code></td>
+            <td>Crazy Taxi: Fare Wars,<br>Crazy Taxi: Double Punch</td>
+            <td><small>primary:</small><code>ms:/MUSIC/CRAZYTAXI</code><br><small>fallback:</small><code>ms:/MUSIC</code></td>
             <td><ul>
                 <li>&#x26A0;&#xFE0F;&nbsp;see issue <a href="https://github.com/hrydgard/ppsspp/issues/15509">#15509</a></li>
                 <li>fallback folder is only checked if no MP3s found in primary folder</li>
@@ -125,7 +125,7 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
         </tr>
         <tr>
             <td>Digital Comics</td>
-            <td><code>ms:/PSP/MUSIC</code>,<br /><code>ms:/MUSIC</code>,<br /><code>ms:/MP3</code></td>
+            <td><code>ms:/PSP/MUSIC</code>,<br><code>ms:/MUSIC</code>,<br><code>ms:/MP3</code></td>
             <td><ul>
                 <li>&#x26A0;&#xFE0F;&nbsp;see issues <a href="https://github.com/hrydgard/ppsspp/issues/20784">#20784</a> and <a href="https://github.com/hrydgard/ppsspp/issues/1755">#1755</a></li>
                 <li>subfolders supported</li>
@@ -134,7 +134,7 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
         </tr>
         <tr>
             <td>Gran Turismo</td>
-            <td><code>ms:/MUSIC</code>,<br /><code>ms:/MUSIC/GTPSP</code></td>
+            <td><code>ms:/MUSIC</code>,<br><code>ms:/MUSIC/GTPSP</code></td>
             <td><ul>
                 <li>you must first make progress in the game</li>
                 <li>folder selection supported</li>
@@ -169,7 +169,7 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
             </ul></td>
         </tr>
         <tr>
-            <td>TOCA Race Driver 3 Challenge,<br />DTM Race Driver 3 Challenge,<br />V8 Supercars Australia 3: Shootout</td>
+            <td>TOCA Race Driver 3 Challenge,<br>DTM Race Driver 3 Challenge,<br>V8 Supercars Australia 3: Shootout</td>
             <td><code>ms:/PSP/MUSIC</code></td>
             <td><ul>
                 <li>subfolders supported</li>
@@ -178,7 +178,7 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
         </tr>
         <tr>
             <td>Ultimate Board Game Collection</td>
-            <td><code>ms:/PSP/MUSIC</code>,<br /><code>ms:/MUSIC</code></td>
+            <td><code>ms:/PSP/MUSIC</code>,<br><code>ms:/MUSIC</code></td>
             <td><ul>
                 <li>subfolders supported</li>
                 <li>playlist customization supported</li>
@@ -341,10 +341,10 @@ The games ignore songs that are shorter than 5 seconds.
 Find the custom tracks folder for your Liberty City Stories version here:
 | Game Version | Serial | Folder |
 | --- | --- | --- |
-| American,<br />Korean | ULUS10041 | `ms:/PSP/SAVEDATA/ULUS10041CUSTOMTRACKS` |
+| American,<br>Korean | ULUS10041 | `ms:/PSP/SAVEDATA/ULUS10041CUSTOMTRACKS` |
 | European | ULES00151 | `ms:/PSP/SAVEDATA/ULES00151CUSTOMTRACKS` |
 | German | ULES00182 | `ms:/PSP/SAVEDATA/ULES00182CUSTOMTRACKS` |
-| Japanese CAPCOM,<br />Japanese Rockstar Classics | ULJM05255,<br />ULJM05885 | `ms:/PSP/SAVEDATA/ULJM05255CUSTOMTRACKS` |
+| Japanese CAPCOM,<br>Japanese Rockstar Classics | ULJM05255,<br>ULJM05885 | `ms:/PSP/SAVEDATA/ULJM05255CUSTOMTRACKS` |
 
 Find the custom tracks folder for your Vice City Stories version here:
 | Game Version | Serial | Folder |
@@ -352,13 +352,13 @@ Find the custom tracks folder for your Vice City Stories version here:
 | American | ULUS10160 | `ms:/PSP/SAVEDATA/ULUS10160CUSTOMTRACKS` |
 | European | ULES00502 | `ms:/PSP/SAVEDATA/ULES00502CUSTOMTRACKS` |
 | German | ULES00503 | `ms:/PSP/SAVEDATA/ULES00503CUSTOMTRACKS` |
-| Japanese CAPCOM,<br />Japanese Rockstar Classics | ULJM05297,<br />ULJM05884 | `ms:/PSP/SAVEDATA/ULJM05297CUSTOMTRACKS` |
+| Japanese CAPCOM,<br>Japanese Rockstar Classics | ULJM05297,<br>ULJM05884 | `ms:/PSP/SAVEDATA/ULJM05297CUSTOMTRACKS` |
 
 Find the custom tracks folder for popular romhacks here:
 | Romhack | Serial | Folder |
 | --- | --- | --- |
 | Sindacco Chronicles <small>(all versions)</small> | ULUS01826 | `ms:/PSP/SAVEDATA/ULUS01826CUSTOMTRACKS` |
-| Seen in Liberty City <small>(1.0.0 and 1.0.1)</small> | ULUS11826 | `ms:/PSP/SAVEDATA/ULUS01826CUSTOMTRACKS`<br /><small>(same as Sindacco Chronicles)</small> |
+| Seen in Liberty City <small>(1.0.0 and 1.0.1)</small> | ULUS11826 | `ms:/PSP/SAVEDATA/ULUS01826CUSTOMTRACKS`<br><small>(same as Sindacco Chronicles)</small> |
 
 ### TOCA Race Driver 2
 

--- a/docs/reference/ios-support.md
+++ b/docs/reference/ios-support.md
@@ -24,7 +24,7 @@ You can install PPSSPP through the App Store:
 
 <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903" class="download-button button-block">
     <div class="button-contents"><img src="/static/img/platform/appstore-badge.svg"
-            alt="Download on the App Store" class="badge"/>Tap here to download PPSSPP from the App Store!</div>
+            alt="Download on the App Store" class="badge">Tap here to download PPSSPP from the App Store!</div>
 </a>
 
 ### Sideloading

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -15,7 +15,7 @@
             aria-hidden="true" class="icon-36 icon-right"></h2>
     <a href="https://play.google.com/store/apps/details?id=org.ppsspp.ppssppgold" class="download-button button-gold button-block">
         <div class="button-contents"><img src="/static/img/platform/googleplay-badge.svg"
-                alt="Get it on Google Play" class="badge"/>Tap here to get PPSSPP Gold from Google Play!</div>
+                alt="Get it on Google Play" class="badge">Tap here to get PPSSPP Gold from Google Play!</div>
     </a>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS<img src="/static/img/icons/ios.svg"
@@ -27,7 +27,7 @@
 
     <h2 class="center-vertical">Buy PPSSPP
         Gold for Windows/macOS<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-36 icon-right">
-        <img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-36 icon-right"/></h2>
+        <img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-36 icon-right"></h2>
 
     <p>Buy PPSSPP Gold to support the project! Choose your level of contribution:</p>
 

--- a/pages/buygold_ios.hbs
+++ b/pages/buygold_ios.hbs
@@ -11,7 +11,7 @@
 
     <a href="https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903" class="download-button button-block">
         <div class="button-contents"><img src="/static/img/platform/appstore-badge.svg"
-                alt="Download on the App Store" class="badge"/>Tap here to download PPSSPP from the App Store!</div>
+                alt="Download on the App Store" class="badge">Tap here to download PPSSPP from the App Store!</div>
     </a>
 
     <p>Then start it up and click the {{> buygold_inapp }} button in the app!</p>

--- a/pages/changepassword.hbs
+++ b/pages/changepassword.hbs
@@ -7,11 +7,11 @@
         <form action="#" onSubmit="return handleChangePasswordForm(event)">
             <label class="not-login-key-only">
                 <div>Previous password</div>
-                <input type="password" id="old_password" />
+                <input type="password" id="old_password">
             </label>
             <label>
                 <div>New password</div>
-                <input type="password" id="new_password" />
+                <input type="password" id="new_password">
             </label>
             <div>
                 <button className="button button--primary margin-top--md" type="submit">Change password</button>

--- a/pages/devbuilds.hbs
+++ b/pages/devbuilds.hbs
@@ -17,7 +17,7 @@
     <div id="twentyBuilds"></div>
     <div>
         <button onclick="loadAllBuilds()" id="showAllButton2" className="button button--primary">Show all</button>
-        <br />
+        <br>
     </div>
 </div>
 

--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -43,7 +43,7 @@
                                 </a>
 
                                 {{ #if whats_this_url }}
-                                <a href="{{whats_this_url}}">{{whats_this}}</a><br />
+                                <a href="{{whats_this_url}}">{{whats_this}}</a><br>
                                 {{ /if }}
 
                             </div>

--- a/pages/login.hbs
+++ b/pages/login.hbs
@@ -19,9 +19,9 @@
                 <form action="#" onSubmit="return handleLoginForm(event)">
                     <div class="alert alert-success" style="display: none;" id="error_message" role="alert"></div>
                     <label for="email">E-mail address</label>
-                    <input type="text" size="38" id="email" name="email" />
+                    <input type="text" size="38" id="email" name="email">
                     <label for="password">Password</label>
-                    <input type="password" size="38" id="password" name="password" />
+                    <input type="password" size="38" id="password" name="password">
                     <div>
                         <button class="button" type="submit">Login</button>
                     </div>

--- a/pages/recoverpassword.hbs
+++ b/pages/recoverpassword.hbs
@@ -19,7 +19,7 @@ noAds="true" }}
                     <form action="#" onSubmit="return handleRecoverPasswordForm(event)">
                         <label>
                             <div>E-mail address</div>
-                            <input type="text" id="email" />
+                            <input type="text" id="email">
                         </label>
                         <div>
                             <button className="button button--primary margin-top--md" type="submit">Recover

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -141,9 +141,9 @@ const tmplAdminPanel = `
 <div class="alert alert-hidden" id="error_message" role="alert"></div>
 <label>
     <div>Name</div>
-    <span><input type="text" size="38" id="freegold_name" /></span>
+    <span><input type="text" size="38" id="freegold_name"></span>
     <div>E-mail address</div>
-    <span><input type="text" size="38" id="freegold_email" /></span>
+    <span><input type="text" size="38" id="freegold_email"></span>
 </label>
 <div>
     <button class="download-button" type="submit">Give free gold</button>
@@ -164,7 +164,7 @@ const tmplAdminPanel = `
 <div class="alert alert-hidden" id="error_message" role="alert"></div>
 <label>
     <div>E-mail address</div>
-    <span><input type="text" size="38" id="magiclink_email" /></span>
+    <span><input type="text" size="38" id="magiclink_email"></span>
 </label>
 <div>
     <button class="download-button" type="submit">Get magic link!</button>

--- a/template/cat_contents.hbs
+++ b/template/cat_contents.hbs
@@ -8,7 +8,7 @@
     <div class="nav-link-container">
         <a href="{{url}}" class="nav-link">
             <div class="title">{{title}}</div>
-            <div class="direction">{{#if summary}}{{{summary}}}<br />Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}
+            <div class="direction">{{#if summary}}{{{summary}}}<br>Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}
             </div>
         </a>
     </div>

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -5,11 +5,11 @@
 <head>
     <title>{{title}} - PPSSPP</title>
 
-    <meta charset="UTF-8"/>
-    <meta name="description" content="{{description}}"/>
+    <meta charset="UTF-8">
+    <meta name="description" content="{{description}}">
     <meta name="keywords" content="PSP, emulator">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-PEQLDV0155"></script>
     <script>

--- a/template/product_card.hbs
+++ b/template/product_card.hbs
@@ -5,7 +5,7 @@
         </div>
         <div class="card-contents">
             <p><span data-fsc-item-path="{{ productId }}" data-fsc-item-pricetotal></span></p>
-            <p>{{ description }}<br /><span>{{ price }}</span></p>
+            <p>{{ description }}<br><span>{{ price }}</span></p>
             <button type="button" class="download-button button-block button-gold" data-fsc-item-path="{{ productId }}"
                 data-fsc-item-path-value="{{ productId }}" data-fsc-action="Reset,Add,Checkout">
                 <div class="button-contents">


### PR DESCRIPTION
Self-closing tags are left over from the XHTML era and are meaningless in HTML5.
<https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags>

> Self-closing tags (`<tag />`) do not exist in HTML.
> 
> If a trailing `/` (slash) character is present in the start tag of an HTML element, HTML parsers ignore that slash character. [...]

Previously, when I uniformed the `br` tags I've changed them all to the self-closing format. This change cleans that up and also removes the trailing slash for other used void elements: `meta`, `hr`, `img`, `input`.

I wanted to open this separately from everything else, as some people still like to use them.
(However, I don't think the trailing slashes are currently being used for every instance of void elements in the project.)

**Note**: `template/feed_atom.hbs` and `template/feed_rss.hbs` are used to generate `.xml` files, so the trailing slash of self-closing tags is *required* there.