### PR TITLE
Move form alerts above the button

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ NOTE: Currently, only hrydgard does this.
 
 Prerequisites: See Local Testing Instructions.
 
-If upgrading PPSSPP versions, regenerate data/downloads.json using util/dirtree-json.
+When upgrading PPSSPP versions, regenerate `data/downloads.json` using `util/dirtree-json`.
 
-That will have its own README.md one day..
+That will have its own README one day...
 
 Use one of the below as appropriate:
 

--- a/pages/buildbotstatus.hbs
+++ b/pages/buildbotstatus.hbs
@@ -4,8 +4,7 @@
     <h1>PPSSPP buildbot status</h1>
     <p>This is the status page of the buildbot that produces builds for <a href="/devbuilds">PPSSPP development
             builds</a></p>
-    <div id="buildbotStatus">
-    </div>
+    <div id="buildbotStatus"></div>
 </div>
 
 <script>

--- a/pages/buildbotstatus.hbs
+++ b/pages/buildbotstatus.hbs
@@ -1,9 +1,9 @@
 {{> common_header this title="Buildbot Status" description="Status page of the PPSSPP development buildbot"}}
 
 <div class="container">
-    <h1>PPSSPP Buildbot Status</h1>
-    <p>This is the status page of the buildbot that produces builds for <a href="/devbuilds">PPSSPP Development
-            Builds</a></p>
+    <h1>PPSSPP buildbot status</h1>
+    <p>This is the status page of the buildbot that produces builds for <a href="/devbuilds">PPSSPP development
+            builds</a></p>
     <div id="buildbotStatus">
     </div>
 </div>

--- a/pages/changepassword.hbs
+++ b/pages/changepassword.hbs
@@ -13,11 +13,11 @@
                 <div>New password</div>
                 <input type="password" id="new_password" />
             </label>
+            <div id="changePasswordStatus"></div>
             <div>
                 <button className="button button--primary margin-top--md" type="submit">Change password</button>
             </div>
         </form>
-        <div id="changePasswordStatus"></div>
     </div>
 
     <div class="not-logged-in-only">

--- a/pages/changepassword.hbs
+++ b/pages/changepassword.hbs
@@ -1,30 +1,40 @@
-{{> common_header this title="Change password" description="Change your login password for ppsspp.org here" }}
+{{> common_header this title="Change Password" description="Change your login password for ppsspp.org here" }}
 
 <div class="container">
-    <h1>Change password</h1>
+    <div class="row">
+        <div class="col-3"></div>
+        <div class="col-6">
+            <div class="card">
+                <div class="card-title">
+                    <h2 class="no-icon">Change password</h2>
+                </div>
 
-    <div class="logged-in-only">
-        <form action="#" onSubmit="return handleChangePasswordForm(event)">
-            <label class="not-login-key-only">
-                <div>Previous password</div>
-                <input type="password" id="old_password" />
-            </label>
-            <label>
-                <div>New password</div>
-                <input type="password" id="new_password" />
-            </label>
-            <div id="changePasswordStatus"></div>
-            <div>
-                <button className="button button--primary margin-top--md" type="submit">Change password</button>
+                <div class="logged-in-only">
+                    <form action="#" onSubmit="return handleChangePasswordForm(event)">
+                        <label class="not-login-key-only">
+                            <div>Previous password</div>
+                            <input type="password" id="old_password" />
+                        </label>
+                        <label>
+                            <div>New password</div>
+                            <input type="password" id="new_password" />
+                        </label>
+                        <div id="changePasswordStatus" class="alert alert-hidden" role="alert"></div>
+                        <div>
+                            <button className="button button--primary margin-top--md" type="submit">Change password</button>
+                        </div>
+                    </form>
+                </div>
+
+                <div class="not-logged-in-only">
+                    <Layout title="Change password" description="Change password">
+                        <p>Not logged in &ndash; can't change password.</p>
+                        <p><a href="/login">Login</a></p>
+                    </Layout>
+                </div>
+
             </div>
-        </form>
-    </div>
-
-    <div class="not-logged-in-only">
-        <Layout title="Change password" description="Change password">
-            <p>Not logged in &ndash; can't change password.</p>
-            <p><a href="/login">Login</a></p>
-        </Layout>
+        </div>
     </div>
 </div>
 

--- a/pages/linktest.hbs
+++ b/pages/linktest.hbs
@@ -1,4 +1,4 @@
-{{> common_header this title="Link test" description="Testing links"}}
+{{> common_header this title="Link Test" description="Testing links"}}
 
 <div class="container">
     <h1>Page for testing links</h1>

--- a/pages/login.hbs
+++ b/pages/login.hbs
@@ -10,18 +10,15 @@
                     <h2 class="no-icon">Login</h2>
                 </div>
 
-                <p>
-                    No account? <a href="/buygold">Buy PPSSPP Gold!</a>
-                </p>
-                <div class="alert alert-info">Note that accounts are for accessing PPSSPP Gold on PC/Mac.
-                </div>
+                <p>No account? <a href="/buygold">Buy PPSSPP Gold!</a></p>
+                <div class="alert alert-info">Note that accounts are for accessing PPSSPP Gold on Windows / macOS.</div>
 
                 <form action="#" onSubmit="return handleLoginForm(event)">
-                    <div class="alert alert-success" style="display: none;" id="error_message" role="alert"></div>
                     <label for="email">E-mail address</label>
                     <input type="text" size="38" id="email" name="email" />
                     <label for="password">Password</label>
                     <input type="password" size="38" id="password" name="password" />
+                    <div id="loginStatus" class="alert alert-hidden" role="alert"></div>
                     <div>
                         <button class="button" type="submit">Login</button>
                     </div>
@@ -29,8 +26,6 @@
                         <a href="/recoverpassword">Forgot your password?</a>
                     </div>
                 </form>
-
-                <div id="loginStatus" class="alert alert-hidden"></div>
             </div>
         </div>
 

--- a/pages/login.hbs
+++ b/pages/login.hbs
@@ -11,7 +11,7 @@
                 </div>
 
                 <p>No account? <a href="/buygold">Buy PPSSPP Gold!</a></p>
-                <div class="alert alert-info">Note that accounts are for accessing PPSSPP Gold on Windows / macOS.</div>
+                <div class="alert alert-info">Note that accounts are for accessing PPSSPP Gold on Windows/macOS.</div>
 
                 <form action="#" onSubmit="return handleLoginForm(event)">
                     <label for="email">E-mail address</label>

--- a/pages/media.hbs
+++ b/pages/media.hbs
@@ -19,7 +19,7 @@
     </div>
 
     {{!-- The dots/circles --}}
-    <div style="text-align:center">
+    <div class="center-text">
         {{#each globals.screenshots}}
         <span role="button" aria-label="select screenshot {{index}}" class="slideshow-dot" onclick="currentSlide({{index}})"></span>
         {{/each}}

--- a/pages/recoverpassword.hbs
+++ b/pages/recoverpassword.hbs
@@ -1,4 +1,4 @@
-{{> common_header this title="Recover your password" description="Recover your password for your PPSSPP Gold account"
+{{> common_header this title="Recover Password" description="Recover your password for your PPSSPP Gold account"
 noAds="true" }}
 
 <div class="container">
@@ -21,13 +21,14 @@ noAds="true" }}
                             <div>E-mail address</div>
                             <input type="text" id="email" />
                         </label>
-                        <div id="recoverPasswordStatus"></div>
+                        <div id="recoverPasswordStatus" class="alert alert-hidden" role="alert"></div>
                         <div>
                             <button className="button button--primary margin-top--md" type="submit">Recover
                                 password</button>
                         </div>
                     </form>
                 </div>
+
             </div>
         </div>
     </div>

--- a/pages/recoverpassword.hbs
+++ b/pages/recoverpassword.hbs
@@ -21,12 +21,12 @@ noAds="true" }}
                             <div>E-mail address</div>
                             <input type="text" id="email" />
                         </label>
+                        <div id="recoverPasswordStatus"></div>
                         <div>
                             <button className="button button--primary margin-top--md" type="submit">Recover
                                 password</button>
                         </div>
                     </form>
-                    <div id="recoverPasswordStatus"></div>
                 </div>
             </div>
         </div>

--- a/pages/requestgold.hbs
+++ b/pages/requestgold.hbs
@@ -1,4 +1,4 @@
-{{> common_header this title="PPSSPP Cross License" description="Request PPSSPP Gold for Android here, if you already have it on PC/Mac" noAds="true" }}
+{{> common_header this title="PPSSPP Gold Cross License" description="Request PPSSPP Gold for Android here, if you already have it on PC/Mac" noAds="true" }}
 
 <div class="container">
 
@@ -17,7 +17,7 @@
 
         <h3>Request</h3>
 
-        <div id="requestPromoCodeStatus"></div>
+        <div id="requestPromoCodeStatus" class="alert alert-hidden" role="alert"></div>
         <form action="#" onSubmit="return handleRequestPromoCodeForm(event)">
             <button className="button button--primary margin-bottom--md margin-top--md" type="submit">
                 Request Google Play promo code

--- a/pages/requestgold.hbs
+++ b/pages/requestgold.hbs
@@ -17,18 +17,16 @@
 
         <h3>Request</h3>
 
+        <div id="requestPromoCodeStatus"></div>
         <form action="#" onSubmit="return handleRequestPromoCodeForm(event)">
             <button className="button button--primary margin-bottom--md margin-top--md" type="submit">
                 Request Google Play promo code
             </button>
         </form>
-        <div id="requestPromoCodeStatus"></div>
 
         <h3>Redeeming the code</h3>
-        <p>
-            <a href="https://support.google.com/googleplay/answer/3422659?hl=en">How to redeem Google Play promo
-                codes</a>
-        </p>
+        <p><a href="https://support.google.com/googleplay/answer/3422659?hl=en">How to redeem Google Play promo
+                codes</a></p>
     </div>
 
     <div class="no-gold-only">

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -716,7 +716,7 @@ const tmplBuildbotStatus = `
 <div class="col-12">
 <div class="card">
 <div class="card-title">
-    <h2 class="no-icon">Buildbot Status</h2>
+    <h2 class="no-icon">Buildbot status</h2>
 </div>
 {{@if(it.building)}}
 <p>Building {{it.tag}}-{{it.revs}} for {{it.building}} ({{it.commit_date}})</p>

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -135,20 +135,19 @@ const tmplAdminPanel = `
 
 <div class="card">
 <div class="card-title">
-    <h2 class="no-icon">Give free gold</h2>
+    <h2 class="no-icon">Give free Gold</h2>
 </div>
 <form action="#" onSubmit="return handleGiveFreeGold(event)">
-<div class="alert alert-hidden" id="error_message" role="alert"></div>
 <label>
     <div>Name</div>
     <span><input type="text" size="38" id="freegold_name" /></span>
     <div>E-mail address</div>
     <span><input type="text" size="38" id="freegold_email" /></span>
 </label>
+<div id="freeGoldStatus" class="alert alert-hidden" role="alert"></div>
 <div>
-    <button class="download-button" type="submit">Give free gold</button>
+    <button class="download-button" type="submit">Give free Gold</button>
 </div>
-<div id="freeGoldStatus"></div>
 </form>
 </div>
 
@@ -161,16 +160,15 @@ const tmplAdminPanel = `
     <h2 class="no-icon">Get magic link</h2>
 </div>
 <form action="#" onSubmit="return handleGetMagicLink(event)">
-<div class="alert alert-hidden" id="error_message" role="alert"></div>
 <label>
     <div>E-mail address</div>
     <span><input type="text" size="38" id="magiclink_email" /></span>
 </label>
+<div id="magicLinkStatus" class="alert alert-hidden" role="alert"></div>
 <div>
     <button class="download-button" type="submit">Get magic link!</button>
 </div>
 <div id="magic_link"></div>
-<div id="magicLinkStatus" class="alert alert-hidden"></div>
 </form>
 </div>
 
@@ -179,16 +177,15 @@ const tmplAdminPanel = `
 <div class="col-6">
 <div class="card">
 <div class="card-title">
-    <h2 class="no-icon">Google Play Codes</h2>
+    <h2 class="no-icon">Google Play codes</h2>
 </div>
-
-<div id="playCodesStats">...</div>
-<div id="googlePlayStatus" class="alert alert-hidden"></div>
 <form action="#" onSubmit="return handleAddGooglePlayCodes(event)">
 <label>
   <div>Codes to add:</div>
   <textarea rows="10" cols="24" id="pending_codes"}></textarea>
 </label>
+<div id="googlePlayStatus" class="alert alert-hidden" role="alert"></div>
+<div id="playCodesStats"></div>
 <div>
   <button class="download-button" type="submit">Add promo codes</button>
 </div>
@@ -314,7 +311,7 @@ async function handleGiveFreeGold(event) {
     let userName = document.getElementById("freegold_name").value.trim();
     let userEmail = document.getElementById("freegold_email").value.trim();
 
-    console.log("Gonna give free gold to " + userEmail + " " + userName);
+    console.log("Gonna give free Gold to " + userEmail + " " + userName);
 
     if (userEmail) {
         userEmail = userEmail.trim();
@@ -340,7 +337,7 @@ async function handleGiveFreeGold(event) {
     }
 
     if (!userEmail || !validateEmailAddress(userEmail)) {
-        setStatusDisplay(ERROR, "freeGoldStatus", "Failed to send free gold - no valid email.");
+        setStatusDisplay(ERROR, "freeGoldStatus", "Failed to send free Gold &ndash; no valid email.");
         return;
     }
 
@@ -353,10 +350,10 @@ async function handleGiveFreeGold(event) {
     const response = await jsonFetch("freegold", freeGoldUser);
     if (response) {
         console.log("gave free gold to " + userName + " '" + userEmail + "'\n" + response.magicLink);
-        setStatusDisplay(SUCCESS, "freeGoldStatus", "Gave free gold to " + userName + " '" + userEmail + "'\n");
+        setStatusDisplay(SUCCESS, "freeGoldStatus", "Gave free Gold to " + userName + " '" + userEmail + "'\n");
         console.log(response);
     } else {
-        setStatusDisplay(ERROR, "freeGoldStatus", "Failed to give free gold");
+        setStatusDisplay(ERROR, "freeGoldStatus", "Failed to give free Gold.");
     }
     return false;
 }
@@ -468,7 +465,7 @@ async function handleLoginForm(event) {
         }
         setStatusDisplay(HIDDEN, "loginStatus");
     } else {
-        setStatusDisplay(ERROR, "loginStatus", "Email/Password didn't match, or account doesn't exist.");
+        setStatusDisplay(ERROR, "loginStatus", "E-mail/password didn't match, or account doesn't exist.");
     }
 
     applyDOMVisibility();
@@ -565,7 +562,7 @@ async function handleRequestPromoCodeForm(event) {
     if (result) {
         setStatusDisplay(SUCCESS, status, result.code);
     } else {
-        setStatusDisplay(ERROR, status, "Failed to make request - duplicate?");
+        setStatusDisplay(ERROR, status, "Failed to make request &ndash; duplicate?");
     }
 }
 
@@ -631,7 +628,7 @@ const tmplShowSuccessfulPurchase = `
 <div class="alert alert-info">NOTE: If no e-mail arrives within a few minutes, please check your spam box.
 If it's not there or you want to use a different e-mail address for login,
 then <a href="mailto:hrydgard+ppssppgold@gmail.com">e-mail me</a> and I'll sort it out.</div>
-<p><a href="{{it.magicLink}}" class="download-button button-gold" style="display:block;">Click here to log in!</a></p>
+<p><a href="{{it.magicLink}}" class="download-button button-gold">Click here to log in!</a></p>
 <p>Paid: {{it.totalDisplay}} ({{it.currency}})</p>
 `;
 
@@ -930,7 +927,7 @@ document.addEventListener('DOMContentLoaded', function () {
     onLoadPage();
 });
 
-/**
+/*
 * Automatic mode assignment according to user-selected system preference.
 */
 let curTheme = localStorage.getItem("theme");
@@ -949,5 +946,5 @@ if (curTheme) {
 }
 
 // Error messages
-const BAD_EMAIL_ADDRESS = "Not a valid e-mail address ";
-const MISSING_PASSWORD = "Please enter a password";
+const BAD_EMAIL_ADDRESS = "Not a valid e-mail address.";
+const MISSING_PASSWORD = "Please enter a password.";

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -3,7 +3,7 @@
 <html lang="en" data-theme="dark">
 
 <head>
-    <title>{{title}} - PPSSPP</title>
+    <title>{{title}} &ndash; PPSSPP</title>
 
     <meta charset="UTF-8"/>
     <meta name="description" content="{{description}}"/>


### PR DESCRIPTION
1. Removed unnecessary inline styles. (Only the one for Google ads remain, but the script for that is using deprecated code so it might get changed when you update it anyway.)
2. Cleaned up (unused) duplicate alerts for some forms.
3. Moved alerts above the form buttons. (Now users can't tap on the same area to trigger the form event again if there was an error.) This is now consistent throughout every form.
4. The "Change password" page is now a card, like the "Recover password" page.
5. Very minor format/stylization changes.