### PR TITLE
ARIA landmark and label fixes

### DIFF
--- a/pages/contact.hbs
+++ b/pages/contact.hbs
@@ -5,44 +5,56 @@
         <div class="col-mb-6">
             <h1>Community, contact info and links</h1>
 
-            <h2>Discord</h2>
-            <p>The PPSSPP Discord is the easiest way to get in touch with other people in the community, and is also
-                useful for quick bug reports and similar.</p>
+            <section aria-labelledby="discord">
+                <h2 id="discord">Discord</h2>
+                <p>The PPSSPP Discord is the easiest way to get in touch with other people in the community, and is also
+                    useful for quick bug reports and similar.</p>
 
-            <iframe src="https://discordapp.com/widget?id=293316141479362560&theme=dark" title="PPSSPP Discord server"
-                width="350" height="500" allowtransparency="true" frameborder="0"></iframe>
+                <iframe src="https://discordapp.com/widget?id=293316141479362560&theme=dark" title="PPSSPP Discord server"
+                    width="350" height="500" allowtransparency="true" frameborder="0"></iframe>
+            </section>
 
-            <h2>PPSSPP Forums</h2>
-            <ul>
-                <li>English and international: <a href="https://forums.ppsspp.org/">PPSSPP Forums</a></li>
-                <li>Chinese: <a href="https://tieba.baidu.com/f?kw=ppsspp&fr=ala0">PPSSPP Tieba community</a></li>
-            </ul>
-
-            <h2>E-mail</h2>
-            <div class="alert alert-info">Note: Before e-mailing, please refer to the <a href="/docs/faq">FAQ</a>.</div>
-            <p>Henrik, the project founder, can be reached on:
+            <section aria-labelledby="forums">
+                <h2 id="forums">PPSSPP Forums</h2>
                 <ul>
-                    <li><a href="mailto:hrydgard+ppsspp@gmail.com">hrydgard+ppsspp@gmail.com</a></li>
-                    <li><a href="mailto:hrydgard+ppssppgold@gmail.com">hrydgard+ppssppgold@gmail.com</a>
-                        for issues regarding PPSSPP Gold purchases and accounts on this website</li>
-                    <li><a href="mailto:hrydgard+translations@gmail.com">hrydgard+translations@gmail.com</a> to submit translations</li>
+                    <li>English and international: <a href="https://forums.ppsspp.org/">PPSSPP Forums</a></li>
+                    <li>Chinese: <a href="https://tieba.baidu.com/f?kw=ppsspp&fr=ala0">PPSSPP Tieba community</a></li>
                 </ul>
-            </p>
+            </section>
 
-            <h2>Web</h2>
-            <p>Henrik's own company is <a href="https://www.millionthline.com">Millionth Line AB</a>.</p>
-            <p>He used to work at <a href="https://www.embark-studios.com/">Embark Studios</a> until fairly recently.</p>
-            <p>Before that he worked at NVIDIA, and previously <a href="https://www.soundtrackyourbrand.com/">Soundtrack
-                Your Brand</a>, and a long time before that Google Zürich.</p>
+            <section aria-labelledby="contact-email">
+                <h2 id="contact-email">E-mail</h2>
+                <div class="alert alert-info">Note: Before e-mailing, please refer to the <a href="/docs/faq">FAQ</a>
+                    and the <a href="/docs/reference/whygold">PPSSPP Gold FAQ</a>.
+                </div>
+                <p>Henrik, the project founder, can be reached on:
+                    <ul>
+                        <li><a href="mailto:hrydgard+ppsspp@gmail.com">hrydgard+ppsspp@gmail.com</a></li>
+                        <li><a href="mailto:hrydgard+ppssppgold@gmail.com">hrydgard+ppssppgold@gmail.com</a>
+                            for issues regarding PPSSPP Gold purchases and accounts on this website</li>
+                        <li><a href="mailto:hrydgard+translations@gmail.com">hrydgard+translations@gmail.com</a> to submit translations</li>
+                    </ul>
+                </p>
+            </section>
 
-            <p>This website was previously built with <a href="https://docusaurus.io/">Docusaurus</a>, but it's now been
-                replaced by a static site built by a fully-custom generator written in Rust.
-                <a href="https://github.com/hrydgard/ppsspp-site/">Source code to generator and site</a>
-            </p>
+            <section aria-labelledby="contact-website">
+                <h2 id="contact-website">Web</h2>
+                <p>Henrik's own company is <a href="https://www.millionthline.com">Millionth Line AB</a>.</p>
+                <p>He used to work at <a href="https://www.embark-studios.com/">Embark Studios</a> until fairly recently.</p>
+                <p>Before that he worked at NVIDIA, and previously <a href="https://www.soundtrackyourbrand.com/">Soundtrack
+                    Your Brand</a>, and a long time before that Google Zürich.</p>
 
-            <h2>X (formerly Twitter)</h2>
-            <p><a href="https://x.com/PPSSPP_emu">Follow @PPSSPP_emu</a></p>
-            <p><a href="https://x.com/henrikrydgard">Follow @henrikrydgard</a></p>
+                <p>This website was previously built with <a href="https://docusaurus.io/">Docusaurus</a>, but it's now been
+                    replaced by a static site built by a fully-custom generator written in Rust.
+                    <a href="https://github.com/hrydgard/ppsspp-site/">Source code to generator and site</a>
+                </p>
+            </section>
+
+            <section aria-labelledby="twitter">
+                <h2 id="twitter">X (formerly Twitter)</h2>
+                <p><a href="https://x.com/PPSSPP_emu">Follow @PPSSPP_emu</a></p>
+                <p><a href="https://x.com/henrikrydgard">Follow @henrikrydgard</a></p>
+            </section>
         </div>
     </div>
 </div>

--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -1,127 +1,135 @@
 {{> common_header this title="Download" description="Download PPSSPP for Android, Windows, macOS, Linux, iOS" }}
 
 <div class="container">
-    <h1>Download PPSSPP</h1>
+    <section aria-labelledby="downloads">
+        <h1 id="downloads">Download PPSSPP</h1>
 
-    <p>What's new in {{ globals.app_version }}? See the <a href="/news">news page</a>!</p>
+        <p>What's new in {{ globals.app_version }}? See the <a href="/news">news page</a>!</p>
 
-    <div class="alert alert-warning gold-only">
-        You've got PPSSPP Gold for Windows/macOS! Downloads are now available below.
-    </div>
-
-    <div class="row">
-        {{#each globals.platforms}}
-        <div class="col-4">
-            <div class="card">
-                <div class="card-title">
-                    {{ #if platform_badge }}
-                    <img src="/static/img/icons/{{platform_badge}}" aria-hidden="true" class="icon-36">
-                    {{ /if}}
-                    <h2>{{ title }}</h2>
-                </div>
-                <div class="card-contents">
-                    {{ #each downloads }}
-
-                        {{ #unless old_build_only }}
-                            <div {{ #if gold_only }} class="gold-only" {{ /if }}>
-                                {{ #if title }}
-                                <h3>{{ title }}</h3>
-                                {{ /if }}
-
-                                <a class="download-button button-block {{#if gold}}button-gold{{/if}}" {{#if url
-                                    }}href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
-                                    <div class="button-contents">
-                                        {{ #if icon }}
-                                        <img src="/static/img/platform/{{icon}}" aria-hidden="true" class="icon-32">
-                                        {{ /if }}
-                                        {{ #if url }}{{name}}{{ /if }}
-                                        {{ #if download_url }}{{name}}{{ /if }}
-                                    </div>
-                                    {{ #if service_image }}
-                                    <img src="{{service_image}}" alt="{{service_alt}}" class="badge">
-                                    {{ /if }}
-                                </a>
-
-                                {{ #if whats_this_url }}
-                                <a href="{{whats_this_url}}">{{whats_this}}</a><br>
-                                {{ /if }}
-
-                            </div>
-                        {{ /unless }}
-
-                    {{ /each }}
-                </div>
-            </div>
+        <div class="alert alert-warning gold-only"> You've got PPSSPP Gold for Windows/macOS!
+            Downloads are now available below.
         </div>
-        {{#if newline}}
-    </div>
-    <div class="row">
-        {{/if}}
-        {{/each}}
-    </div>
 
-    <p class="gold-only">You have Gold for Windows/macOS &ndash; <a href="/requestgold">get PPSSPP Gold for Android for
-            free!</a></p>
-    <p class="no-gold-only">Do you have PPSSPP Gold for Android, and want it for Windows/macOS as well? See instructions
-        <a href="/requestgold">here.</a>
-    </p>
+        <section aria-label="Download options">
+            <div class="row">
+                {{#each globals.platforms}}
+                <div class="col-4">
+                    <article class="card">
+                        <div class="card-title">
+                            {{ #if platform_badge }}
+                            <img src="/static/img/icons/{{platform_badge}}" aria-hidden="true" class="icon-36">
+                            {{ /if}}
+                            <h2>{{ title }}</h2>
+                        </div>
+                        <div class="card-contents">
+                            {{ #each downloads }}
 
-    <h2>Beta testing on Android and iOS</h2>
-    <p>Want to try new builds early, to help testing and debugging of new releases? <a
-            href="/docs/development/beta-testing/">Tap here for information!</a></p>
+                                {{ #unless old_build_only }}
+                                    <div {{ #if gold_only }} class="gold-only" {{ /if }}>
+                                        {{ #if title }}
+                                        <h3>{{ title }}</h3>
+                                        {{ /if }}
 
-    <h2>Unofficial ports and legacy builds</h2>
-    <p><a href="/legacybuilds">A page where you can find</a> cube.elf<img src="/static/img/icons/cube.svg"
-            aria-hidden="true" class="icon-24 icon-right"> and ports for Switch<img src="/static/img/icons/switch.svg"
-            aria-hidden="true" class="icon-24 icon-right">, Web<img src="/static/img/icons/webassembly.svg"
-            aria-hidden="true" class="icon-24 icon-right">, Quest 1<img src="/static/img/icons/vrlegacy.svg"
-            aria-hidden="true" class="icon-24 icon-right"> and other esoteric or old platforms.</p>
+                                        <a class="download-button button-block {{#if gold}}button-gold{{/if}}" {{#if url
+                                            }}href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
+                                            <div class="button-contents">
+                                                {{ #if icon }}
+                                                <img src="/static/img/platform/{{icon}}" aria-hidden="true" class="icon-32">
+                                                {{ /if }}
+                                                {{ #if url }}{{name}}{{ /if }}
+                                                {{ #if download_url }}{{name}}{{ /if }}
+                                            </div>
+                                            {{ #if service_image }}
+                                            <img src="{{service_image}}" alt="{{service_alt}}" class="badge">
+                                            {{ /if }}
+                                        </a>
 
-    <h2>Previous releases</h2>
-    <button class="collapsible">Show downloads of previous releases</button>
-    <div class="collapsible-content">
-        <table class="nice-table">
-            <thead>
-                <tr>
-                    <th>Version</th>
-                    <th>Downloads</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{ #each globals.version_downloads }}
-                <tr>
-                    <td>{{version}}</td>
-                    <td>
-                        {{ #each downloads }}
-                        <span {{ #if gold_only }} class="gold-only-inline" {{ /if }}>
-                            {{ #if icon }}
-                            <img src="/static/img/icons/{{icon}}" class="icon-24 prev-ver-item">
-                            {{ /if }}
-                            {{ #if short_name }}
-                            <a {{ #if gold_only }} class="download-link-gold" {{ else }} class="prev-ver-item" {{ /if }}
-                                href="{{download_url}}">{{short_name}}</a>
-                            {{ /if }}
-                        </span>
-                        {{ /each }}
-                    </td>
-                </tr>
-                {{ /each }}
-            </tbody>
-        </table>
-    </div>
+                                        {{ #if whats_this_url }}
+                                        <a href="{{whats_this_url}}">{{whats_this}}</a><br>
+                                        {{ /if }}
 
-    <h2>Development builds</h2>
+                                    </div>
+                                {{ /unless }}
 
-    <div class="alert alert-warning">
-        Please note that these development builds can be unstable &ndash; if one doesn't work, try an earlier one.
-        Always backup your game saves!
-    </div>
-    <p>Development builds for more platforms will be added soon.</p>
+                            {{ /each }}
+                        </div>
+                    </article>
+                </div>
+                {{#if newline}}
+            </div>
+            <div class="row">
+                {{/if}}
+                {{/each}}
+            </div>
+        </section>
 
-    <p><a href="/devbuilds">Full list of development builds</a></p>
+        <p class="gold-only">You have Gold for Windows/macOS &ndash; <a href="/requestgold">get PPSSPP Gold for Android for
+                free!</a></p>
+        <p class="no-gold-only">Do you have PPSSPP Gold for Android, and want it for Windows/macOS as well? See instructions
+            <a href="/requestgold">here.</a></p>
+    </section>
 
-    <div id="latestBuilds">
-    </div>
+    <section aria-labelledby="betatest">
+        <h2 id="betatest">Beta testing on Android and iOS</h2>
+        <p>Want to try new builds early, to help testing and debugging of new releases? <a
+                href="/docs/development/beta-testing/">Tap here for information!</a></p>
+    </section>
+
+    <section aria-labelledby="legacybuilds">
+        <h2 id="legacybuilds">Unofficial ports and legacy builds</h2>
+        <p><a href="/legacybuilds">A page where you can find</a> cube.elf<img src="/static/img/icons/cube.svg"
+                aria-hidden="true" class="icon-24 icon-right"> and ports for Switch<img src="/static/img/icons/switch.svg"
+                aria-hidden="true" class="icon-24 icon-right">, Web<img src="/static/img/icons/webassembly.svg"
+                aria-hidden="true" class="icon-24 icon-right">, Quest 1<img src="/static/img/icons/vrlegacy.svg"
+                aria-hidden="true" class="icon-24 icon-right"> and other esoteric or old platforms.</p>
+    </section>
+
+    <section aria-labelledby="oldbuilds">
+        <h2 id="oldbuilds">Previous releases</h2>
+        <button class="collapsible">Show downloads of previous releases</button>
+        <div class="collapsible-content">
+            <table class="nice-table">
+                <thead>
+                    <tr>
+                        <th>Version</th>
+                        <th>Downloads</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ #each globals.version_downloads }}
+                    <tr>
+                        <td>{{version}}</td>
+                        <td>
+                            {{ #each downloads }}
+                            <span {{ #if gold_only }} class="gold-only-inline" {{ /if }}>
+                                {{ #if icon }}
+                                <img src="/static/img/icons/{{icon}}" class="icon-24 prev-ver-item">
+                                {{ /if }}
+                                {{ #if short_name }}
+                                <a {{ #if gold_only }} class="download-link-gold" {{ else }} class="prev-ver-item" {{ /if }}
+                                    href="{{download_url}}">{{short_name}}</a>
+                                {{ /if }}
+                            </span>
+                            {{ /each }}
+                        </td>
+                    </tr>
+                    {{ /each }}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section aria-labelledby="devbuilds">
+        <h2 id="devbuilds">Development builds</h2>
+        <div class="alert alert-warning"> Please note that these development builds can be unstable &ndash;
+            if one doesn't work, try an earlier one. Always backup your game saves!
+        </div>
+        <p>Development builds for more platforms will be added soon.</p>
+
+        <p><a href="/devbuilds">Full list of development builds</a></p>
+
+        <div id="latestBuilds"></div>
+    </section>
 
     <script>
         g_downloadPage = true;

--- a/pages/getgames.hbs
+++ b/pages/getgames.hbs
@@ -1,10 +1,9 @@
 {{> common_header this title="How to get games" description="How to get games" }}
 
 <div class="container">
-
     <h1>How to get games for PPSSPP</h1>
 
-    <h3>What are they?</h3>
+    <h2>What are they?</h2>
 
     <p>PSP games are games created for the Sony PlayStation Portable, or PSP for short.
         They are normally sold as either small plastic discs or as downloadable content on PSN.
@@ -13,20 +12,17 @@
         For instructions on how to do this yourself, see the
         <a href="/docs/getting-started/dumping-games">instructions on dumping games</a>.
     </p>
+    <p>PSP games that have been downloaded from PSN onto a real PSP can be copied off the PSP and played directly.</p>
 
-    <p>PSP games that have been downloaded from PSN onto a real PSP can be copied off the PSP and played directly.
-    </p>
+    <h2>How do I get them on my device?</h2>
 
-    <h3>How do I get them on my device?</h3>
-
-    <h4>Windows/macOS</h4>
+    <h3>Windows/macOS</h3>
     <p>If you are running the Windows or macOS version of PPSSPP and you have the game you want to run as an ISO or CSO file,
         just do File-&gt;Load, or use the <b class="inapp">Games</b> tab to navigate to your game.
         Clicking "<b class="inapp">..</b>" moves up a directory level.</p>
 
-    <h4>Android</h4>
+    <h3>Android</h3>
     <p>If you want to play on your Android device (or other portable), then follow these steps:</p>
-
     <ul>
         <li>Install PPSSPP on your device</li>
         <li>Connect the device to your PC where you are storing the ISO or CSO file. Android devices can be easily
@@ -38,13 +34,10 @@
         <li>The game should now start.</li>
     </ul>
 
-    <h4>iOS</h4>
-
-    <p>For iOS instructions and more details, <a href="/docs/getting-started/installing-games-android">click here</a>.
-    </p>
+    <h3>iOS</h3>
+    <p>For iOS instructions and more details, <a href="/docs/getting-started/installing-games-android">click here</a>.</p>
 
     {{> unit }}
-
 </div>
 
 {{> common_footer this }}

--- a/pages/getgames_ios.hbs
+++ b/pages/getgames_ios.hbs
@@ -1,10 +1,9 @@
 {{> common_header this title="How to get games" description="How to get games" }}
 
 <div class="container">
-
     <h1>How to get games for PPSSPP</h1>
 
-    <h3>What are they?</h3>
+    <h2>What are they?</h2>
 
     <p>PSP games are games created for the Sony PlayStation Portable, or PSP for short.
         They are normally sold as either small plastic discs or as downloadable content on PSN.
@@ -13,26 +12,20 @@
         For instructions on how to do this yourself, see the
         <a href="/docs/getting-started/dumping-games">instructions on dumping games</a>.
     </p>
+    <p>PSP games that have been downloaded from PSN onto a real PSP can be copied off the PSP and played directly.</p>
 
-    <p>PSP games that have been downloaded from PSN onto a real PSP can be copied off the PSP and played directly.
-    </p>
+    <h2>How do I get them on my device?</h2>
 
-    <h3>How do I get them on my device?</h3>
-
-    <h4>Mac instructions</h4>
-
+    <h3>Mac instructions</h3>
     <ol>
         <li>Connect your iOS device (iPhone or iPad) via USB to your Mac.</li>
         <li>On your Mac, open the device in Finder. Click the <b class="inapp">Files</b> tab, then you should see PPSSPP listed.</li>
-        <li>Drag your ISO files into the app. To see them, you may have to click the Refresh icon in the app, if
-            it's running.</li>
+        <li>Drag your ISO files into the app. To see them, you may have to click the Refresh icon in the app, if it's running.</li>
     </ol>
 
     <p>After this, the ISO files will be located on the virtual "memory stick". Just pick them from the
         <b class="inapp">Games</b> tab (click the Home icon if you can't find the files).</p>
-
     <p>That's it!</p>
-
 </div>
 
 {{> common_footer this }}

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -1,6 +1,6 @@
 {{> common_header this title="PPSSPP - PSP emulator for Android, Windows, Linux, macOS, iOS" }}
 
-<header class="hero hero-banner">
+<section aria-labelledby="banner-title" class="hero hero-banner">
     <div class='light x1'></div>
     <div class='light x2'></div>
     <div class='light x3'></div>
@@ -13,7 +13,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12">
-                <h1 class="hero-title">PPSSPP <small>{{globals.app_version}}</small></h1>
+                <h1 id="banner-title" class="hero-title">PPSSPP <small>{{globals.app_version}}</small></h1>
                 <p class="hero-subtitle">A PSP emulator</p>
             </div>
             <div class="col-4">
@@ -32,23 +32,21 @@
             </div>
         </div>
     </div>
-</header>
+</section>
 
-<div class="container">
-
-    <div class="row">
+<div class="container small-headers">
+    <section aria-labelledby="news" class="row">
         <div class="col-12">
-            <h3>Latest news</h3>
+            <h2 id="news">Latest news</h2>
             {{#each globals.latest_news}}
             <div class="latest"><a href="{{url}}">{{title}}</a> <small>{{date}}</small></div>
             {{/each}}
         </div>
-    </div>
+    </section>
 
-    <div class="row">
-
+    <section aria-label="Features" class="row">
         <div class="col-4">
-            <h3>Play your PSP games in HD!</h3>
+            <h2>Play your PSP games in HD!</h2>
             <p>PPSSPP can run your PSP games on your PC or Android phone in full HD resolution or even higher.
                 It can also upscale textures to make them sharper, and you can enable post-processing shaders
                 to adjust color and brightness the way you like, and other effects.
@@ -56,7 +54,7 @@
         </div>
 
         <div class="col-4">
-            <h3>Enhance your experience!</h3>
+            <h2>Enhance your experience!</h2>
             <ul class="feature-list">
                 <li>Save and restore game state anywhere, anytime</li>
                 <li>Play in HD resolutions and more</li>
@@ -67,7 +65,7 @@
         </div>
 
         <div class="col-4">
-            <h3>Free &amp; Open Source</h3>
+            <h2>Free &amp; Open Source</h2>
             <p>PPSSPP is an open source project, licensed under the GPL 2.0 (or later).
                 Anyone is welcome to contribute improvements to the code.
                 Thanks to many such contributions, PPSSPP's compatibility is steadily increasing,
@@ -76,9 +74,7 @@
             <p><a href="/docs/development">Development&nbsp;&raquo;</a></p>
             <p><a href="https://github.com/hrydgard/ppsspp">GitHub&nbsp;&raquo;</a></p>
         </div>
-
-    </div>
-
+    </section>
 </div>
 
 {{> common_footer this }}

--- a/pages/media.hbs
+++ b/pages/media.hbs
@@ -1,35 +1,39 @@
 {{> common_header this title="Media" description="Screenshots and videos"}}
 
 <div class="container">
-    <h2>Screenshots</h2>
-    {{!-- Slideshow container --}}
-    <div class="slideshow-container">
-        {{!-- Full-width images with number and caption text --}}
-        {{#each globals.screenshots}}
-        <div class="mySlides fade">
-            <img src="/static/img/screenshots/{{filename}}" alt="screenshot of {{description}}" onclick="plusSlides(1)"
-                {{#if @index}} loading="lazy" {{/if}}>
-            <div class="text">{{description}}</div>
+    <section aria-labelledby="screenshots">
+        <h1 id="screenshots">Screenshots</h1>
+        {{!-- Slideshow container --}}
+        <div class="slideshow-container">
+            {{!-- Full-width images with number and caption text --}}
+            {{#each globals.screenshots}}
+            <div class="mySlides fade">
+                <img src="/static/img/screenshots/{{filename}}" alt="screenshot of {{description}}" onclick="plusSlides(1)"
+                    {{#if @index}} loading="lazy" {{/if}}>
+                <div class="text">{{description}}</div>
+            </div>
+            {{/each}}
+
+            {{!-- Next and previous buttons --}}
+            <div role="button" class="prev" onclick="plusSlides(-1)">&#10094;</div>
+            <div role="button" class="next" onclick="plusSlides(1)">&#10095;</div>
         </div>
-        {{/each}}
 
-        {{!-- Next and previous buttons --}}
-        <div role="button" class="prev" onclick="plusSlides(-1)">&#10094;</div>
-        <div role="button" class="next" onclick="plusSlides(1)">&#10095;</div>
-    </div>
+        {{!-- The dots/circles --}}
+        <div class="center-text">
+            {{#each globals.screenshots}}
+            <span role="button" aria-label="Display screenshot {{index}}" class="slideshow-dot" onclick="currentSlide({{index}})"></span>
+            {{/each}}
+        </div>
+    </section>
 
-    {{!-- The dots/circles --}}
-    <div class="center-text">
-        {{#each globals.screenshots}}
-        <span role="button" aria-label="select screenshot {{index}}" class="slideshow-dot" onclick="currentSlide({{index}})"></span>
-        {{/each}}
-    </div>
-
-    <h2>Videos</h2>
-    <iframe class="video" src="https://www.youtube.com/embed/10_i9cQdQA0" title="PPSSPP - PSP emulator for Android, PC and more!" frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"></iframe>
-    <iframe class="video" src="https://www.youtube.com/embed/y3dgEeDW5Xw" title="PPSSPP VR - Trailer" frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"></iframe>
+    <section aria-labelledby="videos">
+        <h1 id="videos">Videos</h1>
+        <iframe class="video" src="https://www.youtube.com/embed/10_i9cQdQA0" title="PPSSPP - PSP emulator for Android, PC and more!" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"></iframe>
+        <iframe class="video" src="https://www.youtube.com/embed/y3dgEeDW5Xw" title="PPSSPP VR - Trailer" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"></iframe>
+    </section>
 </div>
 
 <script>

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -27,8 +27,8 @@ img.icon-pfp {
     border-radius: 50%;
 }
 
-img.icon-left  { margin-right: 0.5ch; }
-img.icon-right { margin-left:  0.5ch; }
+img.icon-left , i.icon-left  { margin-right: 0.5ch; }
+img.icon-right, i.icon-right { margin-left:  0.5ch; }
 
 .icon-144 { height: 144px !important; width: 144px !important; }
 .icon-96  { height:  96px !important; width:  96px !important; }
@@ -56,10 +56,6 @@ i.icon-ui {
 
 a:hover i.icon-ui {
    background-color: var(--color-a-hover);
-}
-
-i.icon-left {
-    margin-right: 0.5ch;
 }
 
 i.icon-ui-external {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -49,21 +49,15 @@ h4 {
   padding: 12px 0 9px 0;
 }
 
-h1 {
-  font-size: 23pt;
-}
+h1 { font-size: 23pt; }
+h2 { font-size: 18pt; }
+h3 { font-size: 16pt; }
+h4 { font-size: 14pt; }
 
-h2 {
-  font-size: 18pt;
-}
-
-h3 {
-  font-size: 16pt;
-}
-
-h4 {
-  font-size: 14pt;
-}
+.small-headers h1 { font-size: 18pt; }
+.small-headers h2 { font-size: 16pt; }
+.small-headers h3 { font-size: 14pt; }
+.small-headers h4 { font-size: 13pt; }
 
 a {
   color: var(--color-primary);
@@ -79,6 +73,12 @@ a:hover {
   min-height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.contents {
+  flex-grow: 1;
+  background-color: var(--color-contents-background);
+  color: var(--color-text)
 }
 
 /* Utility for images followed by text. */
@@ -126,12 +126,6 @@ footer h2 {
 
 .footer-bottom-text a {
   color: var(--color-primary);
-}
-
-.contents {
-  flex-grow: 1;
-  background-color: var(--color-contents-background);
-  color: var(--color-text)
 }
 
 footer {

--- a/template/blog_page.hbs
+++ b/template/blog_page.hbs
@@ -1,21 +1,17 @@
 {{> common_header this }}
 
 <div class="doc-container">
-    <div class="doc-sidebar" id="localSidebar">
-
+    <aside role="complementary" class="doc-sidebar" id="localSidebar">
         {{{ sidebar }}}
-
         <div class="feed-links">
             <a href="/{{meta.section}}/atom.xml"><img src="/static/img/rss.png" alt="Atom feed" class="icon-24"></a>
         </div>
-
-    </div>
+    </aside>
 
     <div class="doc-contents">
-
         {{#if tags}}
-        <nav class="doc-tagbar">
-            Tags:
+        <nav aria-labelledby="doc-tags" class="doc-tagbar">
+            <span id="doc-tags">Tags:</span>
             <ul class="tag-list">
                 {{#each tags}}
                 <li {{#if selected}}class="selected"{{/if}}>
@@ -30,30 +26,21 @@
 
         {{> unit }}
 
-        <nav class="nav-link-container">
+        <nav aria-label="Pagination" class="nav-link-container">
             {{#if meta.prev}}
             <a href="{{meta.prev.url}}" class="nav-link">
-                <div class="direction">
-                    Prev
-                </div>
-                <div class="title">
-                    &laquo;&nbsp;{{meta.prev.title}}
-                </div>
+                <div class="direction">Prev</div>
+                <div class="title">&laquo;&nbsp;{{meta.prev.title}}</div>
             </a>
             {{/if}}
             {{#if meta.next}}
             <a href="{{meta.next.url}}" class="nav-link next">
-                <div class="direction">
-                    Next
-                </div>
-                <div class="title">
-                    {{meta.next.title}}&nbsp;&raquo;
-                </div>
+                <div class="direction">Next</div>
+                <div class="title">{{meta.next.title}}&nbsp;&raquo;</div>
             </a>
             {{/if}}
         </nav>
     </div>
-
 </div>
 
 {{> common_footer this }}

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -1,4 +1,4 @@
-<div class="article">
+<article class="article">
     <div>
         {{#if is_list_view}}
         <h1><a href="{{ meta.url }}">{{title}}</a></h1>
@@ -6,31 +6,33 @@
         <h1>{{title}}</h1>
         {{/if}}
     </div>
+
     <div class="article-infos">
         <ul>
             {{#with (lookup globals.authors meta.author)}}
             <li>
-                {{#if image_url}}<img src="{{ image_url }}" alt="author" class="icon-pfp icon-24">
-                {{else}}<i role="img" aria-label="author" class="icon-ui icon-ui-user icon-24"></i>
+                {{#if image_url}}<img src="{{ image_url }}" alt="" class="icon-pfp icon-24">
+                {{else}}<i aria-hidden="true" class="icon-ui icon-ui-user icon-24"></i>
                 {{/if}}
                 <b>{{name}}</b>
             </li>
             <li>
-                <i role="img" aria-label="tagged as" class="icon-ui icon-ui-folder"></i>
+                <i aria-hidden="true" class="icon-ui icon-ui-folder"></i>
                 <b>
                 {{#each ../meta.tags}}
                     <a href="/{{ ../../meta.section }}/tags/{{ this }}">{{this}}</a>
                 {{/each}}
                 </b>
             </li>
-            <li><i role="img" aria-label="dated" class="icon-ui icon-ui-clock"></i> <b>{{../meta.date}}</b></li>
-            {{#if url}}<li><a href="{{ url }}"><i aria-label="personal website" class="icon-ui icon-ui-link"></i></a></li>{{/if}}
+            <li><i aria-hidden="true" class="icon-ui icon-ui-clock"></i> <b>{{../meta.date}}</b></li>
+            {{#if url}}<li><a href="{{ url }}"><i aria-label="Personal website" class="icon-ui icon-ui-link"></i></a></li>{{/if}}
             {{#if twitter_url}}<li><a href="{{ twitter_url }}"><i aria-label="X profile" class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
             {{#if github_url}}<li><a href="{{ github_url }}"><i aria-label="GitHub profile" class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
             {{/with}}
         </ul>
     </div>
+
     <div>
         {{{ contents }}}
     </div>
-</div>
+</article>

--- a/template/cat_contents.hbs
+++ b/template/cat_contents.hbs
@@ -3,15 +3,10 @@
 {{{ contents }}}
 
 {{ #each children }}
-
-<nav>
-    <div class="nav-link-container">
-        <a href="{{url}}" class="nav-link">
-            <div class="title">{{title}}</div>
-            <div class="direction">{{#if summary}}{{{summary}}}<br>Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}
-            </div>
-        </a>
-    </div>
+<nav aria-label="Documents in this category" class="nav-link-container">
+    <a href="{{url}}" class="nav-link">
+        <div class="title">{{title}}</div>
+        <div class="direction">{{#if summary}}{{{summary}}}<br>Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}</div>
+    </a>
 </nav>
-
 {{ /each }}

--- a/template/common_footer.hbs
+++ b/template/common_footer.hbs
@@ -1,11 +1,12 @@
-</section>
+</main>
 
-<footer>
+<footer role="contentinfo">
     <div class="container">
         {{ #unless globals.prod }}
         <p>DEVELOPMENT MODE</p>
         {{ /unless }}
-        <div class="row">
+
+        <nav aria-label="Footer" class="row">
             <div class="col-4">
                 <h2>Quick Links</h2>
                 <ul class="clean-list">
@@ -31,7 +32,8 @@
                     <li><a href="/login">Login</a></li>
                 </ul>
             </div>
-        </div>
+        </nav>
+
         <div class="center-text footer-bottom-text">
             Copyright © 2012&ndash;{{ globals.build_year }} PPSSPP Project.
             All trademarks are the property of their respective owners.
@@ -39,8 +41,7 @@
         </div>
     </div>
 </footer>
-</div>
 
+</div> {{!-- page-wrapper --}}
 </body>
-
 </html>

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -55,31 +55,32 @@
 
 <body>
     <div class="page-wrapper">
-        <nav class="top-nav">
-            <div class='menu-button-container' id="burgerButton" onclick="burgerClick()" tabindex="0">
-                <div class='menu-button'></div>
-            </div>
-            <div class="top-nav-logo">
-                <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
-                        class="icon-32">PPSSPP</a>
-            </div>
-            <ul class="menu">
-                {{#each top_nav}}
-                <li {{#if external}}class="external"{{/if}}>
-                    <a href="{{url}}" {{#if selected}}class="selected"{{/if}}>{{{title}}}{{#if external}}{{> link_icon }}{{/if}}</a>
-                </li>
-                {{/each}}
-                <li>
-                    <div class="switch-theme" onclick="switchTheme()">
-                        <i role="button" aria-label="Switch Theme" class="icon-ui icon-ui-moon"></i>
-                    </div>
-                </li>
-            </ul>
-            <div id="loginCorner"><a href="/login">Login</a></div>
-        </nav>
+        <header role="banner">
+            <nav role="navigation" aria-label="Desktop navigation" class="top-nav">
+                <div role="button" aria-label="Open mobile navigation" class='menu-button-container' id="burgerButton"
+                        onclick="burgerClick()" tabindex="0">
+                    <div class='menu-button'></div>
+                </div>
+                <div class="top-nav-logo">
+                    <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
+                            class="icon-32">PPSSPP</a>
+                </div>
+                <ul class="menu">
+                    {{#each top_nav}}
+                    <li {{#if external}}class="external"{{/if}}>
+                        <a href="{{url}}" {{#if selected}}class="selected"{{/if}}>{{{title}}}{{#if external}}{{> link_icon }}{{/if}}</a>
+                    </li>
+                    {{/each}}
+                    <li>
+                        <div class="switch-theme" onclick="switchTheme()">
+                            <i role="button" aria-label="Switch Theme" class="icon-ui icon-ui-moon"></i>
+                        </div>
+                    </li>
+                </ul>
+                <div id="loginCorner"><a href="/login">Login</a></div>
+            </nav>
 
-        <section class="contents">
-            <nav class="burger-sidebar hidden" id="rootSidebar">
+            <nav role="navigation" aria-label="Mobile navigation" class="burger-sidebar hidden" id="rootSidebar">
                 {{!-- We repeat all the same stuff again, but add Login. Better than crazy CSS tricks... --}}
                 <ul class="burger-menu">
                     {{#each top_nav}}
@@ -90,7 +91,10 @@
                     </li>
                     <li>
                         <div id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>Switch Theme</div>
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon icon-left"></i>Switch Theme</div>
                     </li>
                 </ul>
             </nav>
+        </header>
+
+        <main role="main" class="contents">

--- a/template/doc.hbs
+++ b/template/doc.hbs
@@ -1,24 +1,21 @@
 {{> common_header this }}
 
 <div class="doc-container">
-
-    <div class="doc-sidebar" id="localSidebar">
-
-        <nav class="nav-tree">
+    <aside role="complementary" class="doc-sidebar" id="localSidebar">
+        <nav aria-label="Documents list" class="nav-tree">
             {{{ sidebar }}}
         </nav>
-
-    </div>
+    </aside>
 
     <div class="doc-contents">
         {{#if meta.breadcrumbs}}
-        <nav>
+        <nav aria-label="Breadcrumb">
             <ul class="breadcrumb" vocab="https://schema.org/" typeof="BreadcrumbList">
                 {{#each meta.breadcrumbs}}
                 <li property="itemListElement" typeof="ListItem">
                     {{#if url}}<a href="{{url}}" property="item" typeof="WebPage">{{/if}}
                         <span property="name">{{title}}</span>
-                        {{#if url}}</a>{{/if}}
+                    {{#if url}}</a>{{/if}}
                     <meta property="position" content="{{position}}">
                 </li>
                 {{/each}}
@@ -26,7 +23,9 @@
         </nav>
         {{/if}}
 
-        {{{ contents }}}
+        <article>
+            {{{ contents }}}
+        </article>
 
         {{#each tags}}
         <a class="tag-link">{{name}}</a>
@@ -34,30 +33,22 @@
 
         {{> unit}}
 
-        <nav class="nav-link-container">
+        <nav aria-label="Pagination" class="nav-link-container">
             {{ #if meta.prev }}
             <a href="{{ meta.prev.url }}" class="nav-link">
-                <div class="direction">
-                    Prev
-                </div>
-                <div class="title">
-                    &laquo;&nbsp;{{meta.prev.title}}
-                </div>
+                <div class="direction">Prev</div>
+                <div class="title">&laquo;&nbsp;{{meta.prev.title}}</div>
             </a>
             {{ /if }}
+
             {{ #if meta.next }}
             <a href="{{ meta.next.url }}" class="nav-link next">
-                <div class="direction">
-                    Next
-                </div>
-                <div class="title">
-                    {{meta.next.title}}&nbsp;&raquo;
-                </div>
+                <div class="direction">Next</div>
+                <div class="title">{{meta.next.title}}&nbsp;&raquo;</div>
             </a>
             {{ /if }}
         </nav>
     </div>
-
 </div>
 
 {{> common_footer this }}

--- a/template/icons/buygold_inapp.hbs
+++ b/template/icons/buygold_inapp.hbs
@@ -1,1 +1,1 @@
-<b class="inapp">Buy PPSSPP Gold <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24"></b>
+<b class="inapp">Buy PPSSPP Gold<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24 icon-right"></b>

--- a/template/icons/link_icon.hbs
+++ b/template/icons/link_icon.hbs
@@ -1,1 +1,1 @@
-<i aria-label="external link" class="icon-ui icon-ui-external"></i>
+<i aria-hidden="true" class="icon-ui icon-ui-external"></i>

--- a/template/product_card.hbs
+++ b/template/product_card.hbs
@@ -1,11 +1,13 @@
 <div class="col-4">
-    <div class="card">
+    <article class="card">
         <div class="card-title">
             <h2 class="no-icon">{{ title }}</h2>
         </div>
+
         <div class="card-contents">
             <p><span data-fsc-item-path="{{ productId }}" data-fsc-item-pricetotal></span></p>
             <p>{{ description }}<br><span>{{ price }}</span></p>
+
             <button type="button" class="download-button button-block button-gold" data-fsc-item-path="{{ productId }}"
                 data-fsc-item-path-value="{{ productId }}" data-fsc-action="Reset,Add,Checkout">
                 <div class="button-contents">
@@ -14,5 +16,5 @@
                 </div>
             </button>
         </div>
-    </div>
+    </article>
 </div>


### PR DESCRIPTION
- Document content is now wrapped into a `main` landmark (instead of `section`).
- Added `article` element around product cards and blog/document pages.
- Added ARIA-labels to `nav` elements.
- Correct some ARIA-label usage mistakes.
- Fix header levels on the `index`, `media` and both `getgame` pages. (I've added a `small-header` class to simulate the previous sizes, so it continues to look pretty on the grid of `index` page.)
- Added `section` elements and corresponding ARIA-labels on some of the main pages. This needs to be continued later.
- Fix spacing around the icon in the hamburger-menu's Switch Theme item, and inside the Buy PPSSPP Gold template.

I'm a bit torn whether the top navigation bar in the header and the hamburger menu should be 1 or 2 `nav` elements. For now they remain 2 separate.