### PR TITLE
Minor cleanup

### DIFF
--- a/docs/development/porting.md
+++ b/docs/development/porting.md
@@ -13,7 +13,7 @@ Here's an incomplete list of platforms that PPSSPP could or could not be ported 
 | Linux | Done | x86&#x2011;32/&NoBreak;64, ARM32/&NoBreak;64, LoongArch64, RISC&#x2011;V64 |
 | macOS | Done | Limited native UI |
 | iOS | Done | JIT works but not on the App Store builds. |
-| Windows UWP,<br>Xbox Series X\|&NoBreak;S,<br>Xbox One,<br>Windows 10&nbsp;Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_isa] |
+| Windows UWP,<br>Xbox Series X\|&NoBreak;S,<br>Xbox One,<br>Windows 10 Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_isa] |
 | Nintendo Switch | Done | Homebrew enabled consoles only. |
 | Raspberry Pi | Done | R4+ recommended |
 
@@ -21,7 +21,7 @@ Here's an incomplete list of platforms that PPSSPP could or could not be ported 
 [^w_isa]: [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) was never officially supported on Windows.
 [^a_os]: Android 5.0 "Lollipop" or newer. [4.x](https://github.com/hrydgard/ppsspp/pull/19658) support is discontinued.
 [^a_isa]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17908) and [ARMv6 (legacy armeabi)](https://github.com/hrydgard/ppsspp/issues/4798) support on Android is discontinued.
-[^u_mobile]: Windows 10&nbsp;Mobile was never officially supported. JIT didn't work correctly, CPUs in Lumia devices were slow and the graphics driver was extremely buggy.
+[^u_mobile]: Windows 10 Mobile was never officially supported. JIT didn't work correctly, CPUs in Lumia devices were slow and the graphics driver was extremely buggy.
 [^u_isa]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17912) and [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) support on UWP is discontinued.
 
 These platforms were supported once, but aren't anymore due to lack of maintainer interest:

--- a/docs/development/porting.md
+++ b/docs/development/porting.md
@@ -8,21 +8,21 @@ Here's an incomplete list of platforms that PPSSPP could or could not be ported 
 
 | Platform  | State | Comments |
 | --------- | ----- | -------- |
-| Windows[^w_os] | Done | x86&#x2011;32/&NoBreak;64, ARM64 [^w_isa] |
-| Android[^a_os] | Done | x86&#x2011;64, ARM32/&NoBreak;64 [^a_isa] |
+| Windows[^w_os] | Done | x86&#x2011;32/&NoBreak;64, ARM64 [^w_cpu] |
+| Android[^a_os] | Done | x86&#x2011;64, ARM32/&NoBreak;64 [^a_cpu] |
 | Linux | Done | x86&#x2011;32/&NoBreak;64, ARM32/&NoBreak;64, LoongArch64, RISC&#x2011;V64 |
 | macOS | Done | Limited native UI |
 | iOS | Done | JIT works but not on the App Store builds. |
-| Windows UWP,<br>Xbox Series X\|&NoBreak;S,<br>Xbox One,<br>Windows 10 Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_isa] |
+| Windows UWP,<br>Xbox Series X\|&NoBreak;S,<br>Xbox One,<br>Windows 10 Mobile[^u_mobile] | Done | x86&#x2011;64, ARM64 [^u_cpu] |
 | Nintendo Switch | Done | Homebrew enabled consoles only. |
 | Raspberry Pi | Done | R4+ recommended |
 
 [^w_os]: Windows 7 or newer. [XP](https://github.com/hrydgard/ppsspp/pull/11995) support is discontinued. Vista compatibility is not tested.
-[^w_isa]: [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) was never officially supported on Windows.
+[^w_cpu]: [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) was never officially supported on Windows.
 [^a_os]: Android 5.0 "Lollipop" or newer. [4.x](https://github.com/hrydgard/ppsspp/pull/19658) support is discontinued.
-[^a_isa]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17908) and [ARMv6 (legacy armeabi)](https://github.com/hrydgard/ppsspp/issues/4798) support on Android is discontinued.
+[^a_cpu]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17908) and [ARMv6 (legacy armeabi)](https://github.com/hrydgard/ppsspp/issues/4798) support on Android is discontinued.
 [^u_mobile]: Windows 10 Mobile was never officially supported. JIT didn't work correctly, CPUs in Lumia devices were slow and the graphics driver was extremely buggy.
-[^u_isa]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17912) and [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) support on UWP is discontinued.
+[^u_cpu]: [x86&#x2011;32](https://github.com/hrydgard/ppsspp/pull/17912) and [ARM32](https://github.com/hrydgard/ppsspp/pull/20496) support on UWP is discontinued.
 
 These platforms were supported once, but aren't anymore due to lack of maintainer interest:
 

--- a/docs/getting-started/how-to-run-on-xbox.md
+++ b/docs/getting-started/how-to-run-on-xbox.md
@@ -12,7 +12,7 @@ such as Windows 10 and 11, Xbox One and Series X\|&NoBreak;S and potentially oth
 
 On PC there's no real reason to use the UWP build over the regular versions.
 
-Note that PPSSPP has never supported Windows 10&nbsp;Mobile.
+Note that PPSSPP has never supported Windows 10 Mobile.
 
 ## Setup for Xbox
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -15,38 +15,38 @@ PPSSPP does not run those.
 
 [See the download options here.](/download)
 
-On Android<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-right">,
+<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-left"> On Android,
 you can install PPSSPP like any other app from Google Play or from the HUAWEI AppGallery, if that's what your device has.
 If your device doesn't have access to these stores, you can install the app by downloading the APK and then "sideloading" it onto your device.
 
 <!--
-For Android TV<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-right">
+For Android TV<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-left">
 devices, you may have to sideload the [Legacy Edition](/docs/reference/legacy-edition).
 -->
 
-<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;On [iOS](/docs/reference/ios-support),
+<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-24 icon-left"> On [iOS](/docs/reference/ios-support),
 you can find PPSSPP on the Apple App Store.
 
-<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;On Windows,
+<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-left"> On Windows,
 you can use a traditional installer, or you have the option of a "portable" install (just a ZIP file to unzip where you want it).
 Make sure you run the 64-bit executable &ndash; `PPSSPPWindows64.exe` &ndash;  unless you're on a 32-bit computer!
 
-<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;[Windows on ARM](/docs/faq/#arm64win)
+<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-left"> [Windows on ARM](/docs/faq/#arm64win)
 users should download the native ARM64 build.
 
-<img src="/static/img/icons/uwp.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;A [Universal Windows Platform](/docs/getting-started/how-to-run-on-xbox)
+<img src="/static/img/icons/uwp.svg" aria-hidden="true" class="icon-24 icon-left"> A [Universal Windows Platform](/docs/getting-started/how-to-run-on-xbox)
 build, that can be installed even on Xbox consoles, is also available.
 
-<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;On [macOS](/docs/reference/mac), it's a standard `.dmg` install.
+<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-24 icon-left"> On [macOS](/docs/reference/mac), it's a standard `.dmg` install.
 Open the DMG and drag the app to Applications.
 
-<img src="/static/img/icons/linux.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;On Linux,
+<img src="/static/img/icons/linux.svg" aria-hidden="true" class="icon-24 icon-left"> On Linux,
 we have a Flatpak package, and an AppImage that's suitable for most distributions.
 Manual build from source is also possible.
 
-<img src="/static/img/icons/switch.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;PPSSPP is also unofficially available to sideload onto [Nintendo Switch](/legacybuilds).
+<img src="/static/img/icons/switch.svg" aria-hidden="true" class="icon-24 icon-left"> PPSSPP is also unofficially available to sideload onto [Nintendo Switch](/legacybuilds).
 
-<img src="/static/img/icons/vr.svg" aria-hidden="true" class="icon-24 icon-right">&nbsp;Additionally, PPSSPP is available as an APK for [compatible Android VR devices](/docs/reference/vr-apk). PC VR is not currently supported.
+<img src="/static/img/icons/vr.svg" aria-hidden="true" class="icon-24 icon-left"> Additionally, PPSSPP is available as an APK for [compatible Android VR devices](/docs/reference/vr-apk). PC VR is not currently supported.
 
 ## Getting games
 

--- a/docs/reference/custom-background-music.md
+++ b/docs/reference/custom-background-music.md
@@ -155,7 +155,7 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
             <td><code>ms:/MUSIC/OVERWORLD</code></td>
             <td><ul>
                 <li>you must first make progress in the game</li>
-                <li>sample rate: 32,000&nbsp;Hz or 44,100&nbsp;Hz</li>
+                <li>sample rate: 32,000 Hz or 44,100 Hz</li>
                 <li>MP3s should <i>NOT</i> contain an <a href="https://wikipedia.org">ID3v2 tag</a></li>
                 <li>see below for more details</li>
             </ul></td>
@@ -196,8 +196,8 @@ Find the custom music folder for your game here: <sup>(table is not yet complete
 
 <!-- For Surf's Up, the bitrate requirement mentioned by the game's manual is bogus. -->
 
-<div class="alert alert-warning">Unless otherwise noted, games don't recognize or play MP3s that have a sample rate different from 44,100&nbsp;Hz.
-    If your song is playing in incorrect pitch or speed in PPSSPP, or isn't playing at all on PSP, try opening and exporting it with 44,100&nbsp;Hz sample rate using <a href="https://www.audacityteam.org/">Audacity</a>.
+<div class="alert alert-warning">Unless otherwise noted, games don't recognize or play MP3s that have a sample rate different from 44,100 Hz.
+    If your song is playing in incorrect pitch or speed in PPSSPP, or isn't playing at all on PSP, try opening and exporting it with 44,100 Hz sample rate using <a href="https://www.audacityteam.org/">Audacity</a>.
 </div>
 
 ### Additional details
@@ -262,7 +262,7 @@ Then from the main menu navigate to `Gallery -> Custom BGM`.
 (The Gallery is the second option under red colored option.)
 From here you can select 1 custom song for each character from each series that plays when that character initiates an attack during gameplay.
 
-The message "This file cannot be played in SD Gundam G Generation Overworld." shows up when the selected MP3 file has a sample rate that isn't 32,000&nbsp;Hz or 44,100&nbsp;Hz.
+The message "This file cannot be played in SD Gundam G Generation Overworld." shows up when the selected MP3 file has a sample rate that isn't 32,000 Hz or 44,100 Hz.
 
 If an MP3 file contains an [ID3v2 tag](https://en.wikipedia.org/wiki/ID3), the game sometimes plays weird sounds instead, so the tag should be removed in advance.
 
@@ -288,7 +288,7 @@ For the sake of convenience, enable these two settings under `Config -> Preferen
 
 ![Enable the "Force conversion even if only wave files are read" setting, the "Fixed output format for Wave conversion" setting, and select the 44.1kHz from the list of output formats.](/static/img/docs/custom_background_music/atractool_preferences.png)
 
-In the scenario where you have the `Force conversion even if only wave files are read` setting disabled and you want to load `.WAV` files directly, they must be encoded in 16-bit PCM mode with a sample rate of 44,100&nbsp;Hz!
+In the scenario where you have the `Force conversion even if only wave files are read` setting disabled and you want to load `.WAV` files directly, they must be encoded in 16-bit PCM mode with a sample rate of 44,100 Hz!
 If you get an error while loading or encoding a `.WAV` file, it means that it's encoded differently.
 
 In case you want to try out the feature first before you commit yourself to encoding your files, we provide 2 songs for you, already in Atrac3+:
@@ -396,7 +396,7 @@ The game itself is rather complex, so it won't be explained in detail here.
 All custom sound and music files go into the `ms:/MUSIC/BEATERATOR` folder.
 
 The game allows you to import `.WAV` files as sounds to use when creating or editing drum, melody and audio loops.
-They must be encoded in 16-bit PCM mode with a sample rate of either 22,050&nbsp;Hz or 44,100&nbsp;Hz!
+They must be encoded in 16-bit PCM mode with a sample rate of either 22,050 Hz or 44,100 Hz!
 
 The game also allows you to record new sounds using the microphone when creating or editing loops.
 

--- a/docs/reference/process-hacks.md
+++ b/docs/reference/process-hacks.md
@@ -10,7 +10,7 @@ To get it, you can use one of the following methods:
   - by sending the `memory.base`[^ws_bug] event via the [WebSocket debugger API](/docs/reference/websocket-api) <sup>[(since 1.7)](https://github.com/hrydgard/ppsspp/blob/9317fbdd5e8304de7fc0351b95cefbcc53228834/Core/Debugger/WebSocket/DisasmSubscriber.cpp#L255-L267)</sup>
   - by sending the `WM_USER_GET_BASE_POINTER` window message <sup>[(since 1.14)](https://github.com/hrydgard/ppsspp/pull/15748)</sup>
 
-[^ws_bug]: Note: the WebSocket debugger API request returns 8&nbsp;bytes for 32bit `PPSSPPWindows.exe` process on 64bit Windows. Before v1.15, the return value for the `memory.base` event was **bugged** and the upper 32 bits contained the value of another variable, so you need to get rid of that manually e.g. with `& 0xFFFF_FFFF`. See [#17266].
+[^ws_bug]: Note: the WebSocket debugger API request returns 8 bytes for 32bit `PPSSPPWindows.exe` process on 64bit Windows. Before v1.15, the return value for the `memory.base` event was **bugged** and the upper 32 bits contained the value of another variable, so you need to get rid of that manually e.g. with `& 0xFFFF_FFFF`. See [#17266].
 
 ## Useful window messages
 

--- a/docs/reference/texture-replacement.md
+++ b/docs/reference/texture-replacement.md
@@ -66,15 +66,17 @@ ignoreAddress="true"
 
 ### Parts of the hash
 
-Internally, to identify textures, PPSSPP uses a combination of the address the texture is loaded at, a hash of the color palette* (CLUT, which means color look up table), and finally the hash of the actual texture contents, for a total of 96 bits. It's organized like this:
+Internally, to identify textures, PPSSPP uses a combination of the address the texture is loaded at, a hash of the color palette[^clut_hash] (CLUT, which means color look up table), and finally the hash of the actual texture contents, for a total of 96 bits. It's organized like this:
 
-`AAAAAAAACCCCCCCCTTTTTTTT` with an optional `_M` suffix where M is the mip level.
+[^clut_hash]: The dimensions of the texture also affect the CLUT part of the hash. This is an old and unfortunate design decision but doesn't matter very much.
+
+`AAAAAAAACCCCCCCCTTTTTTTT` with an optional `_M` suffix where `M` is the mip level.
 
 The hash simply uses the same hashing PPSSPP internally uses to tell textures apart. Aside from a hash of the image data, it also uses the hash of the palette (for palette-swapped images), and the address of image in memory.
 
 Keep in mind that the `quick` hash especially is not perfect. If you rely only on it, you might find yourself replacing a completely unrelated texture by accident (oops.) Decide your risk carefully.
 
-It's possible to ignore some of these parts by using 00000000 in the hash, but if you do, don't use `hash = quick` (you shouldn't, anyway - the recommended hash is xxh64).
+It's possible to ignore some of these parts by using `00000000` in the hash, but if you do, don't use `hash = quick` (you shouldn't, anyway - the recommended hash is xxh64).
 
 Almost always if you are using a strong hash, it makes sense to zero out the address part, since a game might not always load a texture at the same memory address. Duplicating textures because the address differs is not useful.
 
@@ -152,8 +154,8 @@ When saving textures, they'll be written to disk in png format. While png is oka
 
 From 1.15, PPSSPP supports multiple efficient GPU-native [texture compression formats](https://en.wikipedia.org/wiki/Texture_compression). Here's the current list:
 
-* .KTX2 file format: Basis and UASTC universal compression formats, only!
-* .DDS file format: BC1, BC2, BC3, BC7 (BC1-3 is equivalent to DXT1, DXT3, DXT5). These formats don't work on mobile!
+- .KTX2 file format: Basis and UASTC universal compression formats, only!
+- .DDS file format: BC1, BC2, BC3, BC7 (BC1-3 is equivalent to DXT1, DXT3, DXT5). These formats don't work on mobile!
 
 Basis and UASTC are "intermediate" formats that can be efficiently transcoded to commonly supported native formats (BC1 and ETC2 in case of Basis, BC7 and ASTC 4x4 in case of UASTC). The main advantage is of course that the same texture pack can work on both mobile and desktop with this technology.
 
@@ -191,11 +193,11 @@ Then just refer to the .ktx2 files instead of .png files in the ini. You can del
 
 ### Limitations and properties of KTX2/DDS compressed texture formats
 
-* These formats are supported in PPSSPP 1.15 or later only.
-* Basis is RGB-only, no alpha (but consumes half the memory - just 0.5 bytes per pixel). It also generally doesn't look very good, so only use on textures where you don't need the best quality.
-* UASTC supports full RGBA at excellent quality, not far from native BC7 or ASTC. The data size is bigger than basis though at 1 byte per pixel. Still a huge win over raw RGBA with 4 bytes per pixel...
-* DDS will load marginally faster than KTX2 since no transcoding is needed, but these formats are generally not supported on mobile. So there's a tradeoff.
-* UASTC is not natively supported on D3D9 or OpenGL ES 2.0, it will be transcoded to raw RGBA, eating up the benefits (still usable though).
+- These formats are supported in PPSSPP 1.15 or later only.
+- Basis is RGB-only, no alpha (but consumes half the memory - just 0.5 bytes per pixel). It also generally doesn't look very good, so only use on textures where you don't need the best quality.
+- UASTC supports full RGBA at excellent quality, not far from native BC7 or ASTC. The data size is bigger than basis though at 1 byte per pixel. Still a huge win over raw RGBA with 4 bytes per pixel...
+- DDS will load marginally faster than KTX2 since no transcoding is needed, but these formats are generally not supported on mobile. So there's a tradeoff.
+- UASTC is not natively supported on D3D9 or OpenGL ES 2.0, it will be transcoded to raw RGBA, eating up the benefits (still usable though).
 
 ## Packaging and compatibility
 
@@ -209,9 +211,9 @@ If you're making a texture pack for others to use - that's great.  Otherwise, ig
 
 Filenames are the tricky part here.  Specifically:
 
-* Always use `/` not `\` for directories.  All platforms (even Windows) support `/`, but `\` doesn't work anywhere but Windows.
-* Always use lowercase filenames.  On Windows and Mac, "Hello.png" is the same as "hello.png", but that's not the case everywhere.  Using only lowercase is safest.
-* Avoid special characters: Windows doesn't support a bunch, and they can cause problems for others too.
+- Always use `/` not `\` for directories.  All platforms (even Windows) support `/`, but `\` doesn't work anywhere but Windows.
+- Always use lowercase filenames.  On Windows and Mac, "Hello.png" is the same as "hello.png", but that's not the case everywhere.  Using only lowercase is safest.
+- Avoid special characters: Windows doesn't support a bunch, and they can cause problems for others too.
 
 If you follow those guidelines, even more people will be able to appreciate your hard work.
 
@@ -224,7 +226,3 @@ It can be a bit annoying that KTX2 files don't have thumbnails in the Windows Ex
 ## More info
 
 See [#8715], [#8792], [#4630], and [#9668].
-
-## Asterisks
-
-*: The dimensions of the texture also affect the CLUT part of the hash. This is an old and unfortunate design decision but doesn't matter very much.

--- a/pages/legacybuilds.hbs
+++ b/pages/legacybuilds.hbs
@@ -136,10 +136,10 @@
     <p>Related pull requests: <a href="https://github.com/hrydgard/ppsspp/pull/11001">#11001</a> and
         <a href="https://github.com/hrydgard/ppsspp/pull/13399">#13399</a></p>
 
-    <h3 class="center-vertical">Windows 10&nbsp;Mobile<img src="/static/img/icons/windowsphone.svg"
+    <h3 class="center-vertical">Windows 10 Mobile<img src="/static/img/icons/windowsphone.svg"
             aria-hidden="true" class="icon-36 icon-right"></h3>
-    <p>Once upon a time, back around 2017, I ported PPSSPP to Windows 10&nbsp;Mobile. Unfortunately I never got it to run well enough
-        to be worth releasing, since JIT is fundamentally broken on Windows 10&nbsp; (due to the lack of an API to invalidate the
+    <p>Once upon a time, back around 2017, I ported PPSSPP to Windows 10 Mobile. Unfortunately I never got it to run well enough
+        to be worth releasing, since JIT is fundamentally broken on Windows 10 Mobile (due to the lack of an API to invalidate the
         instruction cache), and the graphics driver was barely functional, causing many glitches.
     </p>
 


### PR DESCRIPTION
Fixes for acc26b6 and 10486c7 and undoing my excessive `&nbsp;` usage.