### PR TITLE
Minor LCP improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,6 @@ Use one of the below as appropriate:
 ## Resources
 
 - [Dark mode guide by Mads Stoumann](https://dev.to/madsstoumann/dark-mode-in-3-lines-of-css-and-other-adventures-1ljj)
-- [Source of homepage's background animation by Warren Davies](https://alvarotrigo.com/blog/animated-backgrounds-css/)
+- [gameroll.jpg](static/img/front/gameroll.jpg) was made with [Photopea](https://www.photopea.com/)
+- [Blurred Lines background animation by Warren Davies](https://alvarotrigo.com/blog/animated-backgrounds-css/)
 - [Unused image for article headers](https://www.zupimages.net/up/22/08/uitq.png)

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -1,15 +1,18 @@
 {{> common_header this title="PPSSPP - PSP emulator for Android, Windows, Linux, macOS, iOS" }}
 
 <section aria-labelledby="banner-title" class="hero hero-banner">
-    <div class='light x1'></div>
-    <div class='light x2'></div>
-    <div class='light x3'></div>
-    <div class='light x4'></div>
-    <div class='light x5'></div>
-    <div class='light x6'></div>
-    <div class='light x7'></div>
-    <div class='light x8'></div>
-    <div class='light x9'></div>
+    <div aria-hidden="true">
+        <img src="/static/img/front/gameroll.jpg" class="hero-bg">
+        <div class='light x1'></div>
+        <div class='light x2'></div>
+        <div class='light x3'></div>
+        <div class='light x4'></div>
+        <div class='light x5'></div>
+        <div class='light x6'></div>
+        <div class='light x7'></div>
+        <div class='light x8'></div>
+        <div class='light x9'></div>
+    </div>
     <div class="container">
         <div class="row">
             <div class="col-12">

--- a/pages/media.hbs
+++ b/pages/media.hbs
@@ -9,7 +9,7 @@
             {{#each globals.screenshots}}
             <div class="mySlides fade">
                 <img src="/static/img/screenshots/{{filename}}" alt="screenshot of {{description}}" onclick="plusSlides(1)"
-                    {{#if @index}} loading="lazy" {{/if}}>
+                    {{#if @first}} fetchpriority="high" {{else}} loading="lazy" {{/if}}>
                 <div class="text">{{description}}</div>
             </div>
             {{/each}}

--- a/static/css/hero.css
+++ b/static/css/hero.css
@@ -1,22 +1,23 @@
-/* Silly moving background CSS from https://alvarotrigo.com/blog/animated-backgrounds-css/ */
-
-.hero {
-  background: #193858;
-  background-image: url("/static/img/front/gameroll.jpg");
-  /* This was made in photopea */
-  background-position: center right;
-  background-repeat: no-repeat;
-  /* Do not repeat the image */
-  background-size: auto 100%;
-}
-
 .hero-banner {
+  background: #193858;
   color: #fff;
-  /* light up the hero title slightly */
   overflow: hidden;
   padding: 3rem 0;
   position: relative;
   text-align: left;
+}
+
+img.hero-bg {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: auto;
+  height: 100%;
+  z-index: auto;
+  object-fit: contain;
+  object-position: center right;
+  pointer-events: none;
+  user-select: none;
 }
 
 .hero-title {
@@ -37,13 +38,12 @@
 }
 
 ul.feature-list li {
-  /* set font size of list item and bullet here */
   list-style-type: square;
-  /* removes default bullet */
   position: relative;
   /* positioning context for bullet */
 }
 
+/* All of the below is for the moving background animation. */
 .light {
   position: absolute;
   width: 0px;


### PR DESCRIPTION
Loading the gameroll image from CSS harms its LCP. We can't easily preload it in the header template, so let's turn it into a proper on-page element instead.

~~Also, prevent the Google ad script from being loaded twice -- it's already included in the header template. (Note that this script has never worked for me so I cannot test this particular change.)~~

EDIT: I dropped the ad script change from this PR, will submit it separately later.