### PR TITLE
Icon class and size cleanup, minor ARIA fixes

### DIFF
--- a/blog/2024-11-26-stuck-in-app-store-review.md
+++ b/blog/2024-11-26-stuck-in-app-store-review.md
@@ -15,7 +15,7 @@ The separate Gold app has now been retired, and replaced with an in-app purchase
 
 Here's an overview, followed by the actual conversation with App Store Review.
 
-PPSSPP is an open source PSP emulator, that lets you run your own [PlayStation Portable](https://en.wikipedia.org/wiki/PlayStation_Portable) games on your various devices. PPSSPP is officially available on Android through [Google Play](https://play.google.com/store/apps/details?id=org.ppsspp.ppsspp), [PC](/download), [Mac](/download), and recently iOS through the [App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903). There is also a [Linux flatpak build](https://flathub.org/apps/org.ppsspp.PPSSPP). The project is ongoing for more than 11 years now, and has been downloaded over 100M times. It has millions of active users on Android.
+PPSSPP is an open source PSP emulator, that lets you run your own [PlayStation Portable](https://en.wikipedia.org/wiki/PlayStation_Portable) games on your various devices. PPSSPP is officially available on Android through [Google Play](https://play.google.com/store/apps/details?id=org.ppsspp.ppsspp), [PC, Mac](/download), and recently iOS through the [App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903). There is also a [Linux flatpak build](https://flathub.org/apps/org.ppsspp.PPSSPP). The project is ongoing for more than 11 years now, and has been downloaded over 100M times. It has millions of active users on Android.
 
 PPSSPP is completely free to download (and compile if you want, since it's open source) but there's also an optional paid version to finance the development and maintenance of the project, buildbot, website, etc.
 
@@ -136,15 +136,15 @@ Five minutes after this rejection was made, my near-identical free version of th
 
 OK, so once again, I will refute your complaints point by point.
 
-##### 4.1 - Design - Copycats
+#### 4.1 - Design - Copycats
 
 Any games console emulator obviously needs to be able to mention what system it emulates. Anything else is unreasonable. Other emulators like Folium do this too.
 
-##### 4.3(a) - Design - Spam
+#### 4.3(a) - Design - Spam
 
 I am the original author of this app. It is not spam, it's just the paid version of PPSSPP - PSP Emulator.
 
-##### Guideline 5.2.2 - Legal
+#### Guideline 5.2.2 - Legal
 
 "The app appears to contain copyrighted video game files"
 

--- a/docs/development/beta-testing.md
+++ b/docs/development/beta-testing.md
@@ -13,17 +13,17 @@ We only have a beta testing program for Android and iOS since Google Play and Te
 We don't have anything like that yet on the other platforms.
 On PC, if you want to help testing stuff before release, download the latest development build from the [buildbot](/devbuilds) and report results.
 
-## Android<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-36 icon-right">
+## Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 The beta testing program for PPSSPP on Android is open.
 
 Tap the appropriate link to join:
 
-<img src="/static/img/platform/ppsspp-icon.png" aria-hidden="true" class="icon-32 icon-left">[Join the beta test!](https://play.google.com/apps/testing/org.ppsspp.ppsspp)
+<img src="/static/img/platform/ppsspp-icon.png" alt="" aria-hidden="true" width="32" height="32" class="icon sp-right">[Join the beta test!](https://play.google.com/apps/testing/org.ppsspp.ppsspp)
 
-<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-32 icon-left">[Join the beta test for PPSSPP Gold!](https://play.google.com/apps/testing/org.ppsspp.ppssppgold)
+<img src="/static/img/platform/ppsspp-icon-gold.png" alt="" aria-hidden="true" width="32" height="32" class="icon sp-right">[Join the beta test for PPSSPP Gold!](https://play.google.com/apps/testing/org.ppsspp.ppssppgold)
 
-## iOS<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-36 icon-right">
+## iOS<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 The beta testing program for PPSSPP on iOS is open through TestFlight.
 

--- a/docs/getting-started/how-to-install-dlc.md
+++ b/docs/getting-started/how-to-install-dlc.md
@@ -1,13 +1,26 @@
 ---
 position: 9
 ---
-
 # How to install DLC
 
-Some PSP games have downloadable content. The PSP is a bit different than modern consoles - it wasn't designed to download DLC directly from the console, instead you downloaded it on your PC and then manually transferred the files over via USB to the "memory stick".
+Some PSP games have downloadable content.
+The PSP is a bit different than modern consoles &ndash; it wasn't designed to download DLC directly from the console,
+instead you downloaded it on your PC and then manually transferred the files over via USB to the "Memory Stick".
 
-There really is no standard for where games like to read there DLC from, but the most common is to simply copy the DLC into `PSP/SAVEDATA`. Not into the save folders belonging to the game, but right alongside.
+There really is no standard for where games like to read there DLC from, but the most common is to simply copy the DLC into `PSP/SAVEDATA`.
+Not into the save folders belonging to the game, but right alongside.
 
 If you can find instructions for how to install the DLC on a real PSP, those instructions should also work in PPSSPP.
 
-In the Android version of PPSSPP, the memory stick is simply the SD card or USB storage of your phone, PPSSPP will create a PSP folder in the root of that. On Windows without installer, the memory stick is the "memstick" subdirectory in the PPSSPP folder. On iOS, it's in `/User/Documents/PSP/`. On Mac and Linux, it's in `~/.config/PPSSPP`.
+In the Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"> version of PPSSPP,
+the Memory Stick is simply the SD card or USB storage of your phone, PPSSPP will create a `PSP` folder in the root of that.
+
+On Windows<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">,
+you can find it easily in the emulator by navigating to <b class="inapp">Settings -> System -> PSP Memory Stick -> Show Memory Stick folder</b>.
+
+On iOS<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">,
+it's in `/User/Documents/PSP/`.
+
+On Mac<img src="/static/img/icons/macos.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">
+and Linux<img src="/static/img/icons/linux.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">,
+it's in `~/.config/PPSSPP/`.

--- a/docs/getting-started/how-to-run-on-xbox.md
+++ b/docs/getting-started/how-to-run-on-xbox.md
@@ -5,7 +5,7 @@ position: 10
 
 ## What is UWP?
 
-<img src="/static/img/icons/uwp.svg" alt="UWP icon" class="icon-96 float-left">
+<img src="/static/img/icons/uwp.svg" alt="Unofficial Universal Windows Platform icon" width="96" height="96" class="icon float-left">
 
 UWP, or Universal Windows Platform, is an application packaging standard for apps that can run on every modern Windows-based platform, such as Windows 10 and 11, Xbox One and Series X\|&NoBreak;S and potentially future Windows-based devices.
 

--- a/docs/getting-started/installing-games-android.md
+++ b/docs/getting-started/installing-games-android.md
@@ -23,7 +23,7 @@ Additionally, this only works from PPSSPP 1.20 and upwards.
 
 1. Use the web interface to upload your ISO files. Done!
 
-## Android<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-36 icon-right">
+## Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 This guide requires a PC.
 
@@ -57,7 +57,7 @@ This guide requires a PC.
 Finally, after starting PPSSPP on your device, you'll be able to either directly browse to it (Android 10 or older, or old installs),
 or you'll be able to tap <b class="inapp">Browse...</b> and select it.
 
-## iOS<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-36 icon-right">
+## iOS<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 The below instructions require a Mac.
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -15,38 +15,42 @@ PPSSPP does not run those.
 
 [See the download options here.](/download)
 
-<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-left"> On Android,
+<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">On Android,
 you can install PPSSPP like any other app from Google Play or from the HUAWEI AppGallery, if that's what your device has.
 If your device doesn't have access to these stores, you can install the app by downloading the APK and then "sideloading" it onto your device.
 
 <!--
-For Android TV<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-left">
+<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">For Android TV
 devices, you may have to sideload the [Legacy Edition](/docs/reference/legacy-edition).
 -->
 
-<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-24 icon-left"> On [iOS](/docs/reference/ios-support),
+<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">On [iOS](/docs/reference/ios-support),
 you can find PPSSPP on the Apple App Store.
 
-<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-left"> On Windows,
+<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">On Windows,
 you can use a traditional installer, or you have the option of a "portable" install (just a ZIP file to unzip where you want it).
 Make sure you run the 64-bit executable &ndash; `PPSSPPWindows64.exe` &ndash;  unless you're on a 32-bit computer!
 
-<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-left"> [Windows on ARM](/docs/faq/#arm64win)
+<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">[Windows on ARM](/docs/faq/#arm64win)
 users should download the native ARM64 build.
 
-<img src="/static/img/icons/uwp.svg" aria-hidden="true" class="icon-24 icon-left"> A [Universal Windows Platform](/docs/getting-started/how-to-run-on-xbox)
+<img src="/static/img/icons/uwp.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">A [Universal Windows Platform](/docs/getting-started/how-to-run-on-xbox)
 build, that can be installed even on Xbox consoles, is also available.
 
-<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-24 icon-left"> On [macOS](/docs/reference/mac), it's a standard `.dmg` install.
+<img src="/static/img/icons/macos.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">On [macOS](/docs/reference/mac),
+it's a standard `.dmg` install.
 Open the DMG and drag the app to Applications.
 
-<img src="/static/img/icons/linux.svg" aria-hidden="true" class="icon-24 icon-left"> On Linux,
+<img src="/static/img/icons/linux.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">On Linux,
 we have a Flatpak package, and an AppImage that's suitable for most distributions.
 Manual build from source is also possible.
 
-<img src="/static/img/icons/switch.svg" aria-hidden="true" class="icon-24 icon-left"> PPSSPP is also unofficially available to sideload onto [Nintendo Switch](/legacybuilds).
+<img src="/static/img/icons/switch.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">PPSSPP
+is also unofficially available to sideload onto [Nintendo Switch](/legacybuilds).
 
-<img src="/static/img/icons/vr.svg" aria-hidden="true" class="icon-24 icon-left"> Additionally, PPSSPP is available as an APK for [compatible Android VR devices](/docs/reference/vr-apk). PC VR is not currently supported.
+<img src="/static/img/icons/vr.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-right">Additionally,
+PPSSPP is available as an APK for [compatible Android VR devices](/docs/reference/vr-apk).
+PC VR is not currently supported.
 
 ## Getting games
 

--- a/docs/getting-started/save-data-and-storage-windows.md
+++ b/docs/getting-started/save-data-and-storage-windows.md
@@ -17,6 +17,6 @@ Edit it with Notepad.
 
 Here's how it works:
 - No `installed.txt`: Memory Stick is in a subfolder called `memstick` right next to the EXE file.
-- `installed.txt` is empty: Memory Stick is in your user folder.
+- `installed.txt` is empty: Memory Stick is in your user's Documents folder &ndash; `%userprofile%\Documents\PPSSPP\`
 - `installed.txt` contains a path: Memory Stick is in that path.
   For example `E:\PSP` or whatever you want.

--- a/docs/reference/how-to-update.md
+++ b/docs/reference/how-to-update.md
@@ -22,7 +22,7 @@ Both on Android and PC, PPSSPP Gold can be installed side by side with the regul
 If you make them share `PSP` (memstick) directories though and keep different version of them,
 they may have problems sharing save states due to the above-mentioned backwards compatibility issue.
 
-## Updating on Android<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-36 icon-right">
+## Updating on Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 If you've installed from Play Store, upgrading should be handled automatically by Google Play on your device.
 
@@ -40,7 +40,7 @@ In summary:
 If you want to install by another method than before, or downgrade to an older version, you need to uninstall first
 (in which case you should make sure to [backup your save games](/docs/getting-started/save-data-and-storage)), since the digital signatures are not compatible.
 
-## Updating on Windows<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-36 icon-right">
+## Updating on Windows<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 If you've been using the installer before and are using the installer again, it should just work to install the new version on top of the old one.
 
@@ -52,7 +52,7 @@ If you've installed PPSSPP by downloading the zip file and unzipped it somewhere
 
 Either will work, matter of taste.
 
-## Updating on Linux<img src="/static/img/icons/linux.svg" aria-hidden="true" class="icon-36 icon-right">
+## Updating on Linux<img src="/static/img/icons/linux.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
 
 ### AppImage (suitable for most Linux distributions)
 

--- a/docs/reference/legacy-edition.md
+++ b/docs/reference/legacy-edition.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-<img src="/static/img/platform/ppsspp-icon-legacy.png" alt="PPSSPP Legacy Edition icon" class="icon-144 float-left">
+<img src="/static/img/platform/ppsspp-icon-legacy.png" alt="PPSSPP Legacy Edition icon" width="144" height="144" class="icon float-left">
 
 The PPSSPP Legacy Edition is really just the same as a regular PPSSPP build, except it has been built specifying an old target Android SDK version (29, specifically).
 

--- a/docs/reference/whygold.md
+++ b/docs/reference/whygold.md
@@ -11,7 +11,7 @@ PPSSPP and PPSSPP Gold have everything you'd want in a PSP emulator:
 
 PPSSPP Gold also:
 
-<img src="/static/img/platform/ppsspp-icon-gold.png" alt="PPSSPP Gold icon" class="icon-96 float-right">
+<img src="/static/img/platform/ppsspp-icon-gold.png" alt="PPSSPP Gold icon" width="96" height="96" class="icon float-right">
 
 * Makes you feel good.
 * Has a fancy golden icon you can show off to your friends.
@@ -21,10 +21,10 @@ PPSSPP Gold also:
 
 ## What platforms is PPSSPP Gold available for?
 
-PPSSPP Gold is currently available for Android<img src="/static/img/icons/android.svg" aria-hidden="true" class="icon-24 icon-right">,
-Windows<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-24 icon-right">,
-macOS<img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-24 icon-right"> and
-iOS<img src="/static/img/icons/ios.svg" aria-hidden="true" class="icon-24 icon-right">.
+PPSSPP Gold is currently available for Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">,
+Windows<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">,
+macOS<img src="/static/img/icons/macos.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"> and
+iOS<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">.
 
 It is not currently available for Linux (or Steam Deck), for example.
 

--- a/pages/buygold.hbs
+++ b/pages/buygold.hbs
@@ -5,29 +5,29 @@
 
     <div class="gold-only">
         <h2 class="center-vertical">Gold already!<img src="/static/img/platform/ppsspp-icon-gold.png"
-                aria-hidden="true" class="icon-36 icon-right"></h2>
+                alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
         <div class="alert alert-warning">You are already a Gold user, are you looking for
             <a href="/download">the downloads</a>?</div>
         <p>Of course, feel free to purchase again if you'd like to support PPSSPP even more.</p>
     </div>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for Android<img src="/static/img/icons/android.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <a href="https://play.google.com/store/apps/details?id=org.ppsspp.ppssppgold" class="download-button button-gold button-block">
         <div class="button-contents"><img src="/static/img/platform/googleplay-badge.svg"
                 alt="Get it on Google Play" class="badge">Tap here to get PPSSPP Gold from Google Play!</div>
     </a>
 
     <h2 class="center-vertical">Buy PPSSPP Gold for iOS<img src="/static/img/icons/ios.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
 
     <p>Starting from 1.19, <a href="/buygold_ios">PPSSPP Gold for iOS</a> is an in-app purchase in the regular PPSSPP app,
         so just download that and click the {{> buygold_inapp }} button!
     </p>
 
-    <h2 class="center-vertical">Buy PPSSPP
-        Gold for Windows/macOS<img src="/static/img/icons/windows.svg" aria-hidden="true" class="icon-36 icon-right">
-        <img src="/static/img/icons/macos.svg" aria-hidden="true" class="icon-36 icon-right"></h2>
+    <h2 class="center-vertical">Buy PPSSPP Gold for Windows/macOS<img src="/static/img/icons/windows.svg"
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left">
+        <img src="/static/img/icons/macos.svg" alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
 
     <p>Buy PPSSPP Gold to support the project! Choose your level of contribution:</p>
 
@@ -55,8 +55,11 @@
     <p>Please note that all price options get you the same thing: the permanent right to download PPSSPP Gold for
         Windows and macOS, a gold account on this site, and Gold downloads for more platforms in the future.</p>
 
-    <p>PPSSPP Gold is currently available for Android, Windows PC, macOS and iOS.</p>
-
+    <p>PPSSPP Gold is currently available for Android<img src="/static/img/icons/android.svg" alt="" aria-hidden="true"
+            width="24" height="24" class="icon sp-left">, Windows<img src="/static/img/icons/windows.svg" alt="" aria-hidden="true"
+            width="24" height="24" class="icon sp-left">, macOS<img src="/static/img/icons/macos.svg" alt="" aria-hidden="true"
+            width="24" height="24" class="icon sp-left"> and iOS<img src="/static/img/icons/ios.svg" alt="" aria-hidden="true"
+            width="24" height="24" class="icon sp-left">.</p>
 </div>
 
 {{> common_footer this }}

--- a/pages/buygold_ios.hbs
+++ b/pages/buygold_ios.hbs
@@ -5,7 +5,7 @@
     <h1>PPSSPP Gold for iOS</h1>
 
     <h2 class="center-vertical">How to buy PPSSPP Gold for iOS<img src="/static/img/icons/ios.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
 
     <p>Download the regular version here, if you don't already have it:</p>
 

--- a/pages/devbuilds.hbs
+++ b/pages/devbuilds.hbs
@@ -5,8 +5,7 @@
 
     <div class="alert alert-warning">
         Please note that these development builds can be unstable &ndash; if one doesn't work, try an earlier one.
-        Always backup your game saves!
-    </div>
+        Always backup your game saves!</div>
 
     <p>Development builds for more platforms will be added soon.</p>
     <p><a href="/buildbotstatus">Buildbot status</a></p>

--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -6,9 +6,8 @@
 
         <p>What's new in {{ globals.app_version }}? See the <a href="/news">news page</a>!</p>
 
-        <div class="alert alert-warning gold-only"> You've got PPSSPP Gold for Windows/macOS!
-            Downloads are now available below.
-        </div>
+        <div class="alert alert-warning gold-only">You've got PPSSPP Gold for Windows/macOS!
+                Downloads are now available below.</div>
 
         <section aria-label="Download options">
             <div class="row">
@@ -17,7 +16,7 @@
                     <article class="card">
                         <div class="card-title">
                             {{ #if platform_badge }}
-                            <img src="/static/img/icons/{{platform_badge}}" aria-hidden="true" class="icon-36">
+                            <img src="/static/img/icons/{{platform_badge}}" alt="" aria-hidden="true" width="36" height="36" class="icon">
                             {{ /if}}
                             <h2>{{ title }}</h2>
                         </div>
@@ -34,7 +33,7 @@
                                             }}href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
                                             <div class="button-contents">
                                                 {{ #if icon }}
-                                                <img src="/static/img/platform/{{icon}}" aria-hidden="true" class="icon-32">
+                                                <img src="/static/img/platform/{{icon}}" alt="" aria-hidden="true" width="32" height="32" class="icon">
                                                 {{ /if }}
                                                 {{ #if url }}{{name}}{{ /if }}
                                                 {{ #if download_url }}{{name}}{{ /if }}
@@ -78,10 +77,10 @@
     <section aria-labelledby="legacybuilds">
         <h2 id="legacybuilds">Unofficial ports and legacy builds</h2>
         <p><a href="/legacybuilds">A page where you can find</a> cube.elf<img src="/static/img/icons/cube.svg"
-                aria-hidden="true" class="icon-24 icon-right"> and ports for Switch<img src="/static/img/icons/switch.svg"
-                aria-hidden="true" class="icon-24 icon-right">, Web<img src="/static/img/icons/webassembly.svg"
-                aria-hidden="true" class="icon-24 icon-right">, Quest 1<img src="/static/img/icons/vrlegacy.svg"
-                aria-hidden="true" class="icon-24 icon-right"> and other esoteric or old platforms.</p>
+                alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"> and ports for Switch<img src="/static/img/icons/switch.svg"
+                alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">, Web<img src="/static/img/icons/webassembly.svg"
+                alt="" aria-hidden="true" width="24" height="24" class="icon sp-left">, Quest 1<img src="/static/img/icons/vrlegacy.svg"
+                alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"> and other esoteric or old platforms.</p>
     </section>
 
     <section aria-labelledby="oldbuilds">
@@ -103,11 +102,11 @@
                             {{ #each downloads }}
                             <span {{ #if gold_only }} class="gold-only-inline" {{ /if }}>
                                 {{ #if icon }}
-                                <img src="/static/img/icons/{{icon}}" class="icon-24 prev-ver-item">
+                                <img src="/static/img/icons/{{icon}}" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left sp-right">
                                 {{ /if }}
                                 {{ #if short_name }}
-                                <a {{ #if gold_only }} class="download-link-gold" {{ else }} class="prev-ver-item" {{ /if }}
-                                    href="{{download_url}}">{{short_name}}</a>
+                                <a {{ #if gold_only }} class="download-link-gold" {{ else }} class="sp-left sp-right" {{ /if }}
+                                        href="{{download_url}}">{{short_name}}</a>
                                 {{ /if }}
                             </span>
                             {{ /each }}
@@ -122,8 +121,7 @@
     <section aria-labelledby="devbuilds">
         <h2 id="devbuilds">Development builds</h2>
         <div class="alert alert-warning"> Please note that these development builds can be unstable &ndash;
-            if one doesn't work, try an earlier one. Always backup your game saves!
-        </div>
+            if one doesn't work, try an earlier one. Always backup your game saves!</div>
         <p>Development builds for more platforms will be added soon.</p>
 
         <p><a href="/devbuilds">Full list of development builds</a></p>

--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -19,15 +19,13 @@
             <div class="col-4">
                 <a href="/download" class="hero-button download-button button-block">
                     <div class="button-contents">
-                        <img src="/static/img/platform/ppsspp-icon.png" aria-hidden="true" class="icon-32">
-                        Download
-                    </div>
+                        <img src="/static/img/platform/ppsspp-icon.png" alt="" aria-hidden="true" width="32" height="32"
+                                class="icon">Download</div>
                 </a>
                 <a href="/buygold" class="hero-button download-button button-block">
                     <div class="button-contents">
-                        <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-32">
-                        Buy PPSSPP Gold
-                    </div>
+                        <img src="/static/img/platform/ppsspp-icon-gold.png" alt="" aria-hidden="true" width="32" height="32"
+                                class="icon">Buy PPSSPP Gold</div>
                 </a>
             </div>
         </div>

--- a/pages/legacybuilds.hbs
+++ b/pages/legacybuilds.hbs
@@ -4,7 +4,7 @@
     <h1>Ports and legacy builds</h1>
 
     <h2 class="center-vertical">PPSSPP for Switch<img src="/static/img/icons/switch.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <p>Ported to the Nintendo Switch by <i>m4xw</i>! See <a href="https://www.patreon.com/m4xwdev">m4xw's Patreon</a>.</p>
     <p>You'll need a Switch enabled for homebrew to run this (and a 7z unpacker).
         You won't find an explanation about that here!</p>
@@ -33,25 +33,25 @@
     </div>
 
     <h2 class="center-vertical">PPSSPP Web for browsers<img src="/static/img/icons/webassembly.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <p><i>roothunter</i> has ported PPSSPP to WebAssembly (WASM), allowing you to run it directly in your browser without any installation.</p>
     <p><a href="https://root-hunter.github.io/ppsspp-web/">Try PPSSPP Web in your browser</a></p>
     <p><a href="https://github.com/root-hunter/ppsspp-wasm">PPSSPP Web repository on GitHub</a></p>
 
 <!--
     <h2 class="center-vertical">Libretro core for RetroArch<img src="/static/img/icons/libretro.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <p></p>
 -->
 
     <h2 class="center-vertical">Legacy Edition for Android<img src="/static/img/platform/ppsspp-icon-legacy.png"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <p>The Legacy Edition for Android lets you use old permission rules on new devices,
         which can help Android TV devices without folder browsers.</p>
     <p><a href="/docs/reference/legacy-edition">PPSSPP Legacy Edition for Android</a>
 
     <h2 class="center-vertical">Cube test program<img src="/static/img/icons/cube.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h2>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>
     <p>A simple PSP program that draws a spinning cube. For testing that the emulator works on your device before you dump
         your UMDs.</p>
     <p>For this testing, these days you can also just use the <a href="/docs/reference/homebrew-store-distribution">
@@ -69,7 +69,7 @@
             <a href="/download">Downloads</a>.</div>
 
     <h3 class="center-vertical">Old Android<img src="/static/img/icons/androidlegacy.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>The last release to support <b>Android 4.1&ndash;4.3 "Jelly Bean"</b> and <b>Android 4.4 "KitKat"</b> is 1.19.3 from July, 2025.</p>
     <p>PPSSPP 1.19.3 for Android: <a href="https://www.ppsspp.org/files/1_19_3/ppsspp.apk">Download APK</a></p>
 
@@ -81,7 +81,7 @@
     <p>PPSSPP 0.9.7.2 for Android: <a href="https://www.ppsspp.org/files/0_9_7_2/ppsspp.apk">Download APK</a></p>
 
     <h3 class="center-vertical">Old Windows<img src="/static/img/icons/windowslegacy.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>The last release to support <b>Direct3D 9</b> (DirectX 9) and <b>DirectSound</b> is 1.19.3 from July, 2025.
         Direct3D 9 was mainly useful on very old laptops with Intel GPUs.</p>
     <p>PPSSPP 1.19.3 installer for Windows: <a href="https://www.ppsspp.org/files/1_19_3/PPSSPPSetup.exe">Download .exe</a></p>
@@ -92,43 +92,43 @@
     <p>PPSSPP 1.8 portable for Windows: <a href="https://www.ppsspp.org/files/1_8_0/ppsspp_win.zip">Download ZIP</a></p>
 
     <h3 class="center-vertical">Old VR<img src="/static/img/icons/vrlegacy.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>The last release that works on (Oculus) <b>Quest 1</b> is v1.17.1 from February, 2024.</p>
     <p>PPSSPP 1.17.1 for VR: <a href="https://www.ppsspp.org/files/1_17_1/ppsspp_vr.apk">Download APK</a></p>
 
     <h3 class="center-vertical">DragonBox Pyra<img src="/static/img/icons/pyra.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>This is a DragonBox Pyra port of PPSSPP from January, 2021. Built by <i>Wally</i>.</p>
     <p><a href="https://pyra-handheld.com/repo/apps/31">DBP repository</a></p>
 
     <h3 class="center-vertical">Pandora<img src="/static/img/icons/pandora.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>This is a Pandora port of PPSSPP. The last release is Build 55 from October, 2020 and is based on version 1.10.3.
         You will have to figure out how to install it. :) Thanks to <i>ptitSeb</i>!</p>
     <p><a href="http://repo.openpandora.org/?page=detail&app=ppsspp_ptitseb">OpenPandora repo</a></p>
 
     <h3 class="center-vertical">BlackBerry 10<img src="/static/img/icons/blackberry.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>This is a BlackBerry 10 port of PPSSPP. Sideload the <code>.bar</code> from your computer using Sachesi or Chrome
         extension. Thanks to <i>xsacha</i> for doing the build!</p>
     <p>PPSSPP 0.9.9 for BlackBerry 10: <a href="https://www.ppsspp.org/files/0_9_9/PPSSPP-v0.9.9.bar">Download .bar</a></p>
 
     <h3 class="center-vertical">Symbian<img src="/static/img/icons/symbian.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>This is a Symbian port of PPSSPP. Thanks to <i>xsacha</i> for doing the build!</p>
     <p>PPSSPP 0.9.9 for Symbian: <a href="https://www.ppsspp.org/files/0_9_9/PPSSPP-v0.9.9.sis">Download .sis</a></p>
 
     <h3 class="center-vertical">MeeGo / Harmattan<img src="/static/img/icons/meego.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>This is a MeeGo "Harmattan" port of PPSSPP for Nokia N9. Thanks to <i>xsacha</i> for doing the build!</p>
     <p>PPSSPP 0.9.5 for MeeGo: <a href="https://www.ppsspp.org/files/0_9_5/PPSSPP-v0.9.5.deb">Download .deb</a></p>
 
     <h3 class="center-vertical">Maemo 5 / Fremantle<img src="/static/img/icons/maemo.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>Support for a Maemo 5 "Fremantle" port for Nokia N900 was added by <i>aapo</i> in March, 2013. Unfortunately no builds remain.</p>
 
     <h3 class="center-vertical">Wii U<img src="/static/img/icons/wiiu.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>A proof-of-concept Wii U port was in development by <i>aliaspider</i> from 2018 to 2020.
         PowerPC JIT support worked, but progress to render games on the GX2 GPU didn't get far enough to run many games.
         With time, interest faded in keeping the port up to date, and eventually big-endian support was dropped altogether.</p>
@@ -137,14 +137,14 @@
         <a href="https://github.com/hrydgard/ppsspp/pull/13399">#13399</a></p>
 
     <h3 class="center-vertical">Windows 10 Mobile<img src="/static/img/icons/windowsphone.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>Once upon a time, back around 2017, I ported PPSSPP to Windows 10 Mobile. Unfortunately I never got it to run well enough
         to be worth releasing, since JIT is fundamentally broken on Windows 10 Mobile (due to the lack of an API to invalidate the
         instruction cache), and the graphics driver was barely functional, causing many glitches.
     </p>
 
     <h3 class="center-vertical">Xbox 360<img src="/static/img/icons/xbox360.svg"
-            aria-hidden="true" class="icon-36 icon-right"></h3>
+            alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h3>
     <p>A proof-of-concept Xbox 360 port was in development by <i>Ced2911</i> during 2013.
         Big-endian PowerPC support and JIT, as well as the Direct3D 9 graphics renderer was first implemented for this port.</p>
     <p><a href="https://github.com/Ced2911/ppsspp/tree/master">Archive of Ced2911's fork</a></p>

--- a/pages/login.hbs
+++ b/pages/login.hbs
@@ -1,10 +1,11 @@
-{{> common_header this title="Login" description="Login form"}}
+{{> common_header this title="Account" description="Manage your user account"}}
 
 {{!-- This takes care of /loginbykey duties too. That's a redirect. --}}
 
 <div class="container">
-    <div class="row">
-        <div class="col-6 not-logged-in-only">
+    <div class="row not-logged-in-only">
+        <div class="col-3"></div>
+        <div class="col-6">
             <div class="card">
                 <div class="card-title">
                     <h2 class="no-icon">Login</h2>
@@ -28,8 +29,10 @@
                 </form>
             </div>
         </div>
+    </div>
 
-        <div class="col-4 card logged-in-only">
+    <div class="row logged-in-only">
+        <div class="col-4 card">
             <div class="card-title">
                 <h2 class="no-icon">Account</h2>
             </div>
@@ -37,7 +40,9 @@
 
             <button onclick="logoutUser()" class="download-button">Log out</button>
         </div>
+    </div>
 
+    <div class="row logged-in-only">
         <div id="adminPanels" class="admin-only"></div>
     </div>
 </div>

--- a/pages/recoverpassword.hbs
+++ b/pages/recoverpassword.hbs
@@ -23,8 +23,7 @@ noAds="true" }}
                         </label>
                         <div id="recoverPasswordStatus" class="alert alert-hidden" role="alert"></div>
                         <div>
-                            <button className="button button--primary margin-top--md" type="submit">Recover
-                                password</button>
+                            <button className="button button--primary margin-top--md" type="submit">Recover password</button>
                         </div>
                     </form>
                 </div>

--- a/pages/requestgold.hbs
+++ b/pages/requestgold.hbs
@@ -15,26 +15,25 @@
 
         <p>If you forgot your password, type your e-mail address in the box below. (Make sure it's right!)</p>
 
-        <h3>Request</h3>
+        <h2>Request</h2>
 
         <div id="requestPromoCodeStatus" class="alert alert-hidden" role="alert"></div>
         <form action="#" onSubmit="return handleRequestPromoCodeForm(event)">
             <button className="button button--primary margin-bottom--md margin-top--md" type="submit">
-                Request Google Play promo code
-            </button>
+                Request Google Play promo code</button>
         </form>
 
-        <h3>Redeeming the code</h3>
-        <p><a href="https://support.google.com/googleplay/answer/3422659?hl=en">How to redeem Google Play promo
-                codes</a></p>
+        <h2>Redeeming the code</h2>
+        <p><a href="https://support.google.com/googleplay/answer/3422659?hl=en">How to redeem Google Play promo codes</a></p>
     </div>
 
     <div class="no-gold-only">
         <h1>PPSSPP Gold &ndash; Cross License</h1>
-        <h3>Do you have PPSSPP Gold for Windows/macOS, but want it for Android?</h3>
+        <h2>Do you have PPSSPP Gold for Windows/macOS, but want it for Android?</h2>
         <p>If so, just <a href="/login?Forward=requestgold">login here</a> and follow the instructions!</p>
-        <h3>Do you have PPSSPP Gold for Android or iOS, but want it for Windows/macOS?</h3>
-        <p>Then please send an e-mail to <a href="mailto:hrydgard+ppsspp@gmail.com">hrydgard+ppssppgold@gmail.com</a>,
+
+        <h2>Do you have PPSSPP Gold for Android or iOS, but want it for Windows/macOS?</h2>
+        <p>Then please send an e-mail to <a href="mailto:hrydgard+ppssppgold@gmail.com">hrydgard+ppssppgold@gmail.com</a>,
             attaching your Google Play receipt. I try to handle all requests within 72 hours, often faster.</p>
     </div>
 

--- a/src/markdown_renderer.rs
+++ b/src/markdown_renderer.rs
@@ -672,7 +672,7 @@ impl<'a> Renderer<'a> {
         let min_depth = toc_data.min_depth;
 
         self.out.push_str("<nav class=\"toc\" aria-labelledby=\"toc\">\n\
-                    <h2 id=\"toc\"><i aria-hidden=\"true\" class=\"icon-ui icon-ui-list icon-left\"></i>Contents</h2>\n<ul>\n");
+                    <h2 id=\"toc\"><i aria-hidden=\"true\" class=\"icon-ui icon-ui-list sp-right\"></i>Contents</h2>\n<ul>\n");
 
         let mut prev_depth: u8 = min_depth;
         let mut first = true;

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -11,31 +11,17 @@ a.download-button>img.badge {
 }
 
 /* Common PNG and SVG icons */
-img.icon-144,
-img.icon-96,
-img.icon-48,
-img.icon-36,
-img.icon-32,
-img.icon-24,
-img.icon-pfp {
+img.icon {
     vertical-align: middle;
     max-width: 100%;
     max-height: 100%;
+    pointer-events: none;
+    user-select: none;
 }
 
-img.icon-pfp {
+img.pfp {
     border-radius: 50%;
 }
-
-img.icon-left , i.icon-left  { margin-right: 0.5ch; }
-img.icon-right, i.icon-right { margin-left:  0.5ch; }
-
-.icon-144 { height: 144px !important; width: 144px !important; }
-.icon-96  { height:  96px !important; width:  96px !important; }
-.icon-48  { height:  48px !important; width:  48px !important; }
-.icon-36  { height:  36px !important; width:  36px !important; }
-.icon-32  { height:  32px !important; width:  32px !important; }
-.icon-24  { height:  24px !important; width:  24px !important; }
 
 /* UI glyphs */
 i.icon-ui {
@@ -56,6 +42,10 @@ i.icon-ui {
 
 a:hover i.icon-ui {
    background-color: var(--color-a-hover);
+}
+
+i.icon-ui-24 {
+    font-size: 24px;
 }
 
 i.icon-ui-external {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -68,6 +68,7 @@ a:hover {
   color: var(--color-a-hover);
 }
 
+/* Page wrapping classes */
 .page-wrapper {
   box-sizing: border-box;
   min-height: 100%;
@@ -81,11 +82,20 @@ a:hover {
   color: var(--color-text)
 }
 
-/* Utility for images followed by text. */
+/* Utility classes */
 .center-vertical {
+  /* Utility for images followed by text. */
   display: flex;
   flex-direction: row;
   align-items: center;
+}
+
+.sp-left {
+  margin-left:  0.5ch;
+}
+
+.sp-right {
+  margin-right: 0.5ch;
 }
 
 .float-left {
@@ -107,6 +117,7 @@ a:hover {
   text-align: center;
 }
 
+/* Footer navigation */
 footer a {
   color: var(--color-text);
 }
@@ -133,27 +144,4 @@ footer {
   flex-shrink: 0;
   background-color: var(--color-header-footer);
   color: var(--color-text)
-}
-
-/*
-  These values work well for both inline code and blocks.
-  Highlight script changes them for clode blocks where necessary.
-*/
-code {
-  font-family: monospace;
-  font-size: 95%;
-  display: inline-block;
-  border-radius: 6px;
-  padding: .2em .4em;
-  margin: 0;
-  background-color: var(--color-gray-800);
-  word-break: break-word;
-  text-align: left;
-}
-
-.inapp {
-  display: inline-block;
-  font-family: Roboto, DroidSans, sans-serif;
-  font-size: 110%;
-  font-weight: bold;
 }

--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -2,6 +2,11 @@
     font-weight: bold;
 }
 
+.top-nav-logo img {
+    margin-left: 0;
+    margin-right: 1ch;
+}
+
 .top-nav {
     flex-grow: 0;
     flex-shrink: 0;
@@ -25,11 +30,6 @@
 
 .top-nav a:hover {
     color: var(--color-a-hover);
-}
-
-.top-nav .center-vertical img {
-    margin-left: 0;
-    margin-right: 1ch;
 }
 
 .menu {

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -31,11 +31,6 @@ a.download-link-gold:hover {
     border-color: var(--color-gold-border-hover);
 }
 
-a.prev-ver-item,
-img.prev-ver-item {
-    margin: 0px 4px;
-}
-
 .button-block {
     display: block;
     width: 100%;
@@ -181,17 +176,12 @@ img.prev-ver-item {
 }
 
 .card {
-    /* General */
     width: 100%;
     height: auto;
-    /* Margin */
     margin: 0.2rem 0;
     padding: 0;
-    /* Color */
     background-color: var(--color-card-background);
-    /* Border */
     border-radius: var(--card-border-radius);
-    /* Margin */
     padding: 1rem;
     box-shadow: 0 3px 5px var(--shadow-color);
 }
@@ -296,4 +286,26 @@ div.forgot-password {
     margin-left: -5px;
     margin-bottom: 12px;
     background-color: var(--color-gray-800);
+}
+
+code {
+  /* These values work well for both inline code and blocks.
+   Highlight script changes them for code blocks where necessary.
+ */
+  font-family: monospace;
+  font-size: 95%;
+  display: inline-block;
+  border-radius: 6px;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: var(--color-gray-800);
+  word-break: break-word;
+  text-align: left;
+}
+
+.inapp {
+  display: inline-block;
+  font-family: Roboto, DroidSans, sans-serif;
+  font-size: 110%;
+  font-weight: bold;
 }

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -132,7 +132,7 @@ const tmplUserInfo = `
 </p>
 <p>E-mail: {{it.email}}</p>
 {{ @if (it.goldUser) }}
-<p class="center-vertical">Gold status!<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24 icon-right"></p>
+<p class="center-vertical">Gold status!<img src="/static/img/platform/ppsspp-icon-gold.png" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"></p>
 {{ /if }}
 <p><a href="/changepassword">Change password</a></p>
 </div>
@@ -189,13 +189,13 @@ const tmplAdminPanel = `
 </div>
 <form action="#" onSubmit="return handleAddGooglePlayCodes(event)">
 <label>
-  <div>Codes to add:</div>
+    <div>Codes to add:</div>
     <textarea rows="10" cols="24" id="pending_codes"></textarea>
 </label>
 <div id="googlePlayStatus" class="alert alert-hidden" role="alert"></div>
 <div id="playCodesStats"></div>
 <div>
-  <button class="download-button" type="submit">Add promo codes</button>
+    <button class="download-button" type="submit">Add promo codes</button>
 </div>
 </form>
 </div>
@@ -252,23 +252,21 @@ const tmplPlayCodes = `
 `;
 
 const tmplLoginCorner = `
-<a href='/login' class="center-vertical">
+<a href='/login' class="center-vertical"
 {{@if(it.loggedIn)}}
-<i aria-label="Profile" class="icon-ui icon-ui-user"></i>
+aria-label="Profile"><i class="icon-ui icon-ui-user"></i></a>
 {{#else}}
-Login
+>Login</a>
 {{/if}}
-</a>
 `;
 
 const tmplLoginItem = `
 <a href='/login'>
 {{@if(it.loggedIn)}}
-<i aria-hidden="true" class="icon-ui icon-ui-user icon-left"></i>{{it.name}}
+<i aria-hidden="true" class="icon-ui icon-ui-user sp-right"></i>{{it.name}}</a>
 {{#else}}
-Login
+Login</a>
 {{/if}}
-</a>
 `;
 
 async function applyDOMVisibility() {

--- a/template/blog_page.hbs
+++ b/template/blog_page.hbs
@@ -4,7 +4,7 @@
     <aside role="complementary" class="doc-sidebar" id="localSidebar">
         {{{ sidebar }}}
         <div class="feed-links">
-            <a href="/{{meta.section}}/atom.xml"><img src="/static/img/rss.png" alt="Atom feed" class="icon-24"></a>
+            <a href="/{{meta.section}}/atom.xml"><img src="/static/img/rss.png" alt="Atom feed" width="24" height="24" class="icon"></a>
         </div>
     </aside>
 

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -11,8 +11,8 @@
         <ul>
             {{#with (lookup globals.authors meta.author)}}
             <li>
-                {{#if image_url}}<img src="{{ image_url }}" alt="" class="icon-pfp icon-24">
-                {{else}}<i aria-hidden="true" class="icon-ui icon-ui-user icon-24"></i>
+                {{#if image_url}}<img src="{{ image_url }}" alt="" aria-hidden="true" width="24" height="24" class="icon pfp">
+                {{else}}<i aria-hidden="true" class="icon-ui icon-ui-user icon-ui-24"></i>
                 {{/if}}
                 <b>{{name}}</b>
             </li>
@@ -24,10 +24,10 @@
                 {{/each}}
                 </b>
             </li>
-            <li><i aria-hidden="true" class="icon-ui icon-ui-clock"></i> <b>{{../meta.date}}</b></li>
-            {{#if url}}<li><a href="{{ url }}"><i aria-label="Personal website" class="icon-ui icon-ui-link"></i></a></li>{{/if}}
-            {{#if twitter_url}}<li><a href="{{ twitter_url }}"><i aria-label="X profile" class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
-            {{#if github_url}}<li><a href="{{ github_url }}"><i aria-label="GitHub profile" class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
+            <li><i aria-hidden="true" class="icon-ui icon-ui-clock sp-right"></i><b>{{../meta.date}}</b></li>
+            {{#if url}}<li><a href="{{ url }}" aria-label="Personal website"><i class="icon-ui icon-ui-link"></i></a></li>{{/if}}
+            {{#if twitter_url}}<li><a href="{{ twitter_url }}" aria-label="X profile"><i class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
+            {{#if github_url}}<li><a href="{{ github_url }}" aria-label="GitHub profile"><i class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
             {{/with}}
         </ul>
     </div>

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -62,8 +62,8 @@
                     <div class='menu-button'></div>
                 </div>
                 <div class="top-nav-logo">
-                    <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" aria-hidden="true"
-                            class="icon-32">PPSSPP</a>
+                    <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" alt="" aria-hidden="true"
+                            width="32" height="32" class="icon">PPSSPP</a>
                 </div>
                 <ul class="menu">
                     {{#each top_nav}}
@@ -91,7 +91,7 @@
                     </li>
                     <li>
                         <div id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i aria-hidden="true" class="icon-ui icon-ui-moon icon-left"></i>Switch Theme</div>
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon sp-right"></i>Switch Theme</div>
                     </li>
                 </ul>
             </nav>

--- a/template/icons/buygold_inapp.hbs
+++ b/template/icons/buygold_inapp.hbs
@@ -1,1 +1,1 @@
-<b class="inapp">Buy PPSSPP Gold<img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-24 icon-right"></b>
+<b class="inapp">Buy PPSSPP Gold<img src="/static/img/platform/ppsspp-icon-gold.png" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left"></b>

--- a/template/product_card.hbs
+++ b/template/product_card.hbs
@@ -11,9 +11,8 @@
             <button type="button" class="download-button button-block button-gold" data-fsc-item-path="{{ productId }}"
                 data-fsc-item-path-value="{{ productId }}" data-fsc-action="Reset,Add,Checkout">
                 <div class="button-contents">
-                    <img src="/static/img/platform/ppsspp-icon-gold.png" aria-hidden="true" class="icon-48">
-                    Buy PPSSPP Gold
-                </div>
+                    <img src="/static/img/platform/ppsspp-icon-gold.png" alt="" aria-hidden="true" width="48" height="48"
+                            class="icon">Buy PPSSPP Gold</div>
             </button>
         </div>
     </article>


### PR DESCRIPTION
This isn't anything flashy, but it's something I've been postponing for a while now.

- Cleans up all of the `icon-XY` CSS classes. Sizing is now done via the `width` and `height` img attributes again. Previously I had uniformly converted all of these into CSS classes for each size. Recently I've learned that doing this is bad design, especially for layout calculations. (I'm learning by doing. 😛) Now the `icon` class only specifies other properties.
  - This also means that icons no longer cover up the whole screen when style is disabled in the browser.
  - Icons now cannot be selected.
  - For spacing around icons use the now appropriately named `sp-left` / `sp-right` classes. (Most of the time 1 is enough.) For bigger images, `float-left` / `float-right` have existed since #138 .
- Made sure every `img` tag has an `alt` attribute.
- ARIA fixes for links that contain only a glyph (but no text).
- Minor HTML whitespacing fixes (to get rid of some unnecessarily rendered spaces)
- Fix header levels on 2 pages.
- Add platform icons to the recent page about DLC installation.

<img width="712" height="668" alt="image" src="https://github.com/user-attachments/assets/ff69be11-dc8d-42ac-a639-aa52656922a7" />
