### PR TITLE
Only load Google ad script once

### DIFF
--- a/template/unit.hbs
+++ b/template/unit.hbs
@@ -1,6 +1,4 @@
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3281131109267988"
-    crossorigin="anonymous"></script>
-{{!-- Responsive Black --}}
+{{!-- adsbygoogle.js is linked in common_header. --}}
 <ins class="adsbygoogle"
     style="display:block"
     data-full-width-responsive="true"


### PR DESCRIPTION
Broken out from #150. (Easier to revert this way.)

Prevent the Google ad script from being loaded twice or more -- it's already linked in the header template, no need to link it in the template as well.