### PR TITLE
Modernize buttons, clean up related CSS and JS

### DIFF
--- a/pages/download.hbs
+++ b/pages/download.hbs
@@ -20,17 +20,17 @@
                             {{ /if}}
                             <h2>{{ title }}</h2>
                         </div>
+
                         <div class="card-contents">
                             {{ #each downloads }}
-
                                 {{ #unless old_build_only }}
                                     <div {{ #if gold_only }} class="gold-only" {{ /if }}>
                                         {{ #if title }}
                                         <h3>{{ title }}</h3>
                                         {{ /if }}
 
-                                        <a class="download-button button-block {{#if gold}}button-gold{{/if}}" {{#if url
-                                            }}href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
+                                        <a class="download-button button-block {{#if gold}}button-gold{{/if}}" {{#if url}}
+                                            href="{{url}}" {{ /if }} {{ #if download_url }}href="{{download_url}}" {{ /if }}>
                                             <div class="button-contents">
                                                 {{ #if icon }}
                                                 <img src="/static/img/platform/{{icon}}" alt="" aria-hidden="true" width="32" height="32" class="icon">
@@ -46,10 +46,8 @@
                                         {{ #if whats_this_url }}
                                         <a href="{{whats_this_url}}">{{whats_this}}</a><br>
                                         {{ /if }}
-
                                     </div>
                                 {{ /unless }}
-
                             {{ /each }}
                         </div>
                     </article>
@@ -85,8 +83,8 @@
 
     <section aria-labelledby="oldbuilds">
         <h2 id="oldbuilds">Previous releases</h2>
-        <button class="collapsible">Show downloads of previous releases</button>
-        <div class="collapsible-content">
+        <details>
+            <summary class="collapsible">Show downloads of previous releases</summary>
             <table class="nice-table">
                 <thead>
                     <tr>
@@ -99,23 +97,24 @@
                     <tr>
                         <td>{{version}}</td>
                         <td>
-                            {{ #each downloads }}
-                            <span {{ #if gold_only }} class="gold-only-inline" {{ /if }}>
-                                {{ #if icon }}
-                                <img src="/static/img/icons/{{icon}}" alt="" aria-hidden="true" width="24" height="24" class="icon sp-left sp-right">
-                                {{ /if }}
-                                {{ #if short_name }}
-                                <a {{ #if gold_only }} class="download-link-gold" {{ else }} class="sp-left sp-right" {{ /if }}
-                                        href="{{download_url}}">{{short_name}}</a>
-                                {{ /if }}
-                            </span>
-                            {{ /each }}
+                            <div class="center-vertical">
+                                {{ #each downloads }}
+                                <span {{ #if gold_only }} class="gold-only-inline" {{ /if }}>
+                                    {{ #if icon }}{{!-- This has to look this ridiculous to avoid HTML whitespace rendering. --}}
+                                    <img src="/static/img/icons/{{icon}}" alt="" aria-hidden="true" width="24" height="24"
+                                            class="icon sp-left sp-right">{{ /if }}{{ #if short_name }}<a href="{{download_url}}"
+                                            {{ #if gold_only }} class="mini-button button-gold" {{ else }} class="sp-left sp-right"
+                                            {{ /if }}>{{short_name}}</a>
+                                    {{ /if }}
+                                </span>
+                                {{ /each }}
+                            </div>
                         </td>
                     </tr>
                     {{ /each }}
                 </tbody>
             </table>
-        </div>
+        </details>
     </section>
 
     <section aria-labelledby="devbuilds">

--- a/pages/legacybuilds.hbs
+++ b/pages/legacybuilds.hbs
@@ -11,8 +11,8 @@
     <div class="alert alert-warning">NOTE! This is currently not working on the latest version of the Switch OS. Work needs to be done to update it.</div>
     <p><a href="https://www.ppsspp.org/files/Switch/Release_PPSSPP_Standalone_11.09.2024.7z">Download PPSSPP 1.17.1+ for
         Switch</a> &ndash; Sept 11, 2024</p>
-    <button class="collapsible">Show downloads of previous builds</button>
-    <div class="collapsible-content">
+    <details>
+        <summary class="collapsible">Show downloads of previous builds</summary>
         <table class="nice-table">
             <thead>
                 <tr>
@@ -30,7 +30,7 @@
                 </tr>
             </tbody>
         </table>
-    </div>
+    </details>
 
     <h2 class="center-vertical">PPSSPP Web for browsers<img src="/static/img/icons/webassembly.svg"
             alt="" aria-hidden="true" width="36" height="36" class="icon sp-left"></h2>

--- a/pages/media.hbs
+++ b/pages/media.hbs
@@ -8,23 +8,34 @@
             {{!-- Full-width images with number and caption text --}}
             {{#each globals.screenshots}}
             <div class="mySlides fade">
-                <img src="/static/img/screenshots/{{filename}}" alt="screenshot of {{description}}" onclick="plusSlides(1)"
-                    {{#if @first}} fetchpriority="high" {{else}} loading="lazy" {{/if}}>
-                <div class="text">{{description}}</div>
+                <button type="button" class="invisible-button" onclick="plusSlides(1)">
+                    <img src="/static/img/screenshots/{{filename}}" alt="screenshot of {{description}}"
+                            {{#if @first}} fetchpriority="high" {{else}} loading="lazy" {{/if}}>
+                </button>
+                <div class="slide-text">{{description}}</div>
+                {{!--<div class="slide-numbers">{{index}} / {{globals.screenshots.length}}</div>--}}
             </div>
             {{/each}}
 
             {{!-- Next and previous buttons --}}
-            <div role="button" class="prev" onclick="plusSlides(-1)">&#10094;</div>
-            <div role="button" class="next" onclick="plusSlides(1)">&#10095;</div>
+            <button type="button" aria-label="Previous screenshot" class="prev" onclick="plusSlides(-1)">
+                <span aria-hidden="false">&#10094;</span>
+            </button>
+            <button type="button" aria-label="Next screenshot" class="next" onclick="plusSlides(1)">
+                <span aria-hidden="true">&#10095;</span>
+            </button>
         </div>
 
-        {{!-- The dots/circles --}}
-        <div class="center-text">
-            {{#each globals.screenshots}}
-            <span role="button" aria-label="Display screenshot {{index}}" class="slideshow-dot" onclick="currentSlide({{index}})"></span>
-            {{/each}}
-        </div>
+        {{!-- The quick navigation dots/circles --}}
+        <nav aria-label="Gallery pagination">
+            <ul class="slideshow-quicknav">
+                {{#each globals.screenshots}}
+                <li>
+                    <button type="button" aria-label="Display screenshot {{index}}" class="slideshow-dot" onclick="currentSlide({{index}})"></button>
+                </li>
+                {{/each}}
+            </ul>
+        </nav>
     </section>
 
     <section aria-labelledby="videos">

--- a/static/css/gallery.css
+++ b/static/css/gallery.css
@@ -3,7 +3,6 @@
     display: flex;
     position: relative;
     aspect-ratio: 1920 / 1088;
-    margin-bottom: 30px;
 }
 
 .slideshow-container img {
@@ -14,6 +13,14 @@
 /* Hide the images by default */
 .slideshow-container .mySlides {
     display: none;
+}
+
+.invisible-button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
 }
 
 /* Next & previous buttons */
@@ -29,6 +36,8 @@
     font-weight: bold;
     font-size: 18px;
     transition: 0.2s ease;
+    background: transparent;
+    border: 0;
     border-radius: 0 3px 3px 0;
     user-select: none;
 }
@@ -46,7 +55,7 @@
 }
 
 /* Caption text */
-.slideshow-container .text {
+.slideshow-container .slide-text {
     color: #f2f2f2;
     background-color: rgba(0, 0, 0, 0.5);
     font-size: 15px;
@@ -58,33 +67,55 @@
 }
 
 /* Number text (1/3 etc) */
-.slideshow-container .numbertext {
+.slideshow-container .slide-numbers {
     color: #f2f2f2;
     font-size: 12px;
     padding: 8px 12px;
     position: absolute;
-    top: 0;
+    bottom: 16px;
+    right: 0;
 }
 
-/* The dots/bullets/indicators */
+/* The quick navigation dots/bullets */
+.slideshow-quicknav {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    list-style: none;
+    padding: 0;
+    margin-top: 20px;
+}
+
 .slideshow-dot {
-    height: 15px;
-    width: 15px;
-    margin: 0 2px;
+    height: 18px;
+    width: 18px;
+    margin: 0.5ch;
     background-color: #bbb;
+    border: none;
     border-radius: 50%;
     display: inline-block;
     transition: background-color 0.2s ease;
+    cursor: pointer;
 }
 
 .slideshow-dot:hover {
     background-color: var(--color-primary);
-    cursor: pointer;
 }
 
 .slideshow-dot.active {
     background-color: #717171;
-    margin-bottom: 2px;
+    transform: translateY(-2px);
+}
+
+@media (pointer: coarse) {
+    /* Extra size for touchscreen */
+    .slideshow-dot {
+        height: 24px;
+        width: 24px;
+        margin: 1ch;
+    }
 }
 
 /* Fading animation */

--- a/static/css/hamburger.css
+++ b/static/css/hamburger.css
@@ -1,3 +1,4 @@
+/* Hamburger menu container */
 .burger-sidebar {
     background-color: var(--color-gray-900);
     display: block;
@@ -17,44 +18,41 @@
     margin-right: 1ch;
 }
 
+/* Hamburger menu items */
 .burger-menu {
     list-style: none;
-    padding-left: 0px;
+    padding: 0;
 }
 
 .burger-menu>li {
     border-bottom: 2px solid var(--color-gray-800);
     padding: 0px;
     font-size: 14pt;
-    /*text-align: center;*/
 }
 
 .burger-menu>li:hover {
     background-color: var(--color-gray-700);
 }
 
-.burger-menu>li a {
-    padding: 11px;
-    display: block;
-    color: var(--color-text);
-}
-
-.burger-menu>li a:hover i.icon-ui {
+.burger-menu>li:hover i.icon-ui {
     background-color: var(--color-text);
 }
 
-.burger-menu>li .switch-theme {
+.burger-menu>li a,
+.burger-menu>li button {
+    display: block;
+    text-align: left;
     padding: 11px;
+    color: var(--color-text);
 }
 
-.burger-menu>li .switch-theme:hover {
-    text-decoration: underline;
+.burger-menu>li button {
+    width: 100%;
+    background: transparent;
+    border: none;
     cursor: pointer;
 }
 
-.burger-menu>li #loginItem a,
-.burger-menu>li .switch-theme {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+.burger-menu>li button:hover {
+    text-decoration: underline;
 }

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -40,7 +40,8 @@ i.icon-ui {
     mask-repeat: no-repeat;
 }
 
-a:hover i.icon-ui {
+a:hover i.icon-ui,
+button:hover i.icon-ui {
    background-color: var(--color-a-hover);
 }
 

--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -1,3 +1,4 @@
+/* Top navigation bar container */
 .top-nav-logo {
     font-weight: bold;
 }
@@ -32,6 +33,19 @@
     color: var(--color-a-hover);
 }
 
+.top-nav button {
+    color: var(--color-gray-0);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+}
+
+.top-nav button:hover {
+    color: var(--color-a-hover);
+    text-decoration: underline;
+}
+
+/* Menu items of top navigation bar */
 .menu {
     display: flex;
     flex-direction: row;
@@ -52,28 +66,20 @@
     border-bottom: 3px solid var(--color-primary);
 }
 
-.menu>li .switch-theme:hover {
-    color: var(--color-primary);
-    text-decoration: underline;
-    cursor: pointer;
-}
-
-.menu>li .switch-theme:hover i.icon-ui {
-    background-color: var(--color-a-hover);
-}
-
 .menu>li.external {
     /* Hide external list items */
     display: none;
 }
 
 @media (min-width: 850px) {
+    /* Only show external list items if screen is wide */
     .menu>li.external {
         display: flex;
     }
 }
 
-.menu-button-container {
+/* Hamburger menu toggle button */
+.menu-button {
     display: none;
     height: 100%;
     width: 30px;
@@ -86,13 +92,10 @@
     margin-left: -12px;
 }
 
-#menu-toggle {
-    display: none;
-}
-
-.menu-button,
-.menu-button::before,
-.menu-button::after {
+/* Draw the hamburger icon using CSS and pseudo-elements */
+.menu-icon,
+.menu-icon::before,
+.menu-icon::after {
     display: block;
     background-color: var(--color-gray-0);
     position: absolute;
@@ -103,63 +106,41 @@
     pointer-events: none;
 }
 
-.menu-button::before {
+.menu-icon::before {
     content: '';
     margin-top: -8px;
 }
 
-.menu-button::after {
+.menu-icon::after {
     content: '';
     margin-top: 8px;
 }
 
-#loginCorner {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+.menu-button:hover .menu-icon,
+.menu-button:hover .menu-icon::before,
+.menu-button:hover .menu-icon::after {
+   background-color: var(--color-a-hover);
 }
 
+/* Login item of top navigation bar */
 #loginCorner i.icon-ui {
     font-size: 24px;
 }
 
+/* Narrow screens */
 @media (max-width: 699px) {
     /* Hide the login corner */
     #loginCorner {
         display: none;
     }
 
-    .menu-button-container {
+    /* Show the hamburger button */
+    .menu-button {
         display: flex;
     }
 
+    /* Hide the menu items */
     .menu {
-        z-index: 289;
-        position: absolute;
-        top: 0;
-        margin-top: 50px;
-        left: 0;
-        flex-direction: column;
-        width: 100%;
-        justify-content: left;
-        align-items: top;
-    }
-
-    .menu>li {
         display: none;
-        text-align: left;
-        margin: 0;
-        padding: 0.5em 0;
-        width: 100%;
-        color: white;
-        background-color: #222;
-    }
-
-    .menu>li a {
-        display: block;
-    }
-
-    .menu>li:not(:last-child) {
-        border-bottom: 1px solid #444;
     }
 }

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -1,3 +1,4 @@
+/* Special behaviour */
 .logged-in-only {
     display: none;
 }
@@ -14,23 +15,7 @@
     display: none;
 }
 
-a.download-link-gold {
-    color: var(--color-gold-border-hover);
-    background-color: var(--color-gold);
-    border: var(--button-border-width) solid var(--color-gold-border);
-    border-radius: var(--button-border-radius);
-    font-weight: var(--button-font-weight);
-    padding: 4px;
-    margin: 0px 4px;
-    user-select: none;
-}
-
-a.download-link-gold:hover {
-    color: var(--color-gold-border-hover);
-    background-color: var(--color-gold-hover);
-    border-color: var(--color-gold-border-hover);
-}
-
+/* Links and buttons */
 .button-block {
     display: block;
     width: 100%;
@@ -49,6 +34,7 @@ a.download-link-gold:hover {
     padding: var(--button-padding-vertical) var(--button-padding-horizontal);
     margin: 8px 0px;
     text-align: center;
+    -webkit-user-select: none;
     user-select: none;
     overflow: hidden;
 }
@@ -63,22 +49,38 @@ a.download-link-gold:hover {
     margin-right: 1ch;
 }
 
-.download-button.button-gold {
+.mini-button {
+    background-color: var(--button-background-color);
+    border: var(--button-border-width) solid var(--button-border-color);
+    border-radius: var(--button-border-radius);
+    color: var(--color-text-inverse);
+    font-weight: var(--button-font-weight);
+    padding: 4px;
+    margin: 0 0.5ch;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.download-button.button-gold,
+.mini-button.button-gold {
     background-color: var(--color-gold);
     border-color: var(--color-gold-border);
 }
 
-.download-button:hover {
+.download-button:hover,
+.mini-button:hover {
     color: var(--color-text-inverse);
     background-color: var(--button-background-color-hover);
     text-decoration: none;
 }
 
-.download-button.button-gold:hover {
+.download-button.button-gold:hover,
+.mini-button.button-gold:hover {
     background-color: var(--color-gold-hover);
     border-color: var(--color-gold-border-hover);
 }
 
+/* Notification boxes */
 .alert {
     display: block;
     box-shadow: 0 3px 5px var(--shadow-color);
@@ -115,6 +117,11 @@ a.download-link-gold:hover {
     display: none;
 }
 
+/* Collapsible button */
+summary {
+    cursor: pointer;
+}
+
 .collapsible {
     background-color: var(--color-primary);
     color: var(--color-text-inverse);
@@ -125,30 +132,16 @@ a.download-link-gold:hover {
     text-align: left;
     outline: none;
     font-size: 15px;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
-.collapsible:after {
-    content: '\002B';
-    color: white;
-    font-weight: bold;
-    float: right;
-    margin-left: 5px;
-}
-
-.collapsible.active {
+details[open] .collapsible {
     color: white;
     background-color: #555;
 }
 
-.collapsible.active:after {
-    content: "\2212";
-}
-
-.collapsible-content {
-    display: none;
-    overflow: hidden;
-}
-
+/* Formatted table */
 .nice-table {
     width: 100%;
     display: table;
@@ -175,6 +168,7 @@ a.download-link-gold:hover {
     border-bottom: 4px solid var(--color-table-border);
 }
 
+/* Product cards */
 .card {
     width: 100%;
     height: auto;
@@ -221,11 +215,7 @@ a.download-link-gold:hover {
     padding: 1rem;
 }
 
-.video {
-    aspect-ratio: 16 / 9;
-    width: 100%;
-}
-
+/* Forms */
 form input {
     width: 100%;
     margin: 3px 0px 13px 0px;
@@ -261,6 +251,7 @@ form button {
     padding: var(--button-padding-vertical) var(--button-padding-horizontal);
     margin: 8px 0px;
     text-align: center;
+    -webkit-user-select: none;
     user-select: none;
     white-space: nowrap;
     overflow: hidden;
@@ -272,26 +263,20 @@ form button:hover {
     text-decoration: none;
 }
 
-div.forgot-password {
-    margin-top: 20px;
+/* Misc stuff */
+.video {
+    aspect-ratio: 16 / 9;
+    width: 100%;
 }
 
-/* Style the list */
-.url-display {
-    display: inline-block;
-    padding: 4px 10px;
-    border-radius: 10px;
-    list-style: none;
-    margin-top: 12px;
-    margin-left: -5px;
-    margin-bottom: 12px;
-    background-color: var(--color-gray-800);
+.forgot-password {
+    margin-top: 20px;
 }
 
 code {
   /* These values work well for both inline code and blocks.
    Highlight script changes them for code blocks where necessary.
- */
+   */
   font-family: monospace;
   font-size: 95%;
   display: inline-block;

--- a/static/script/main.js
+++ b/static/script/main.js
@@ -254,7 +254,7 @@ const tmplPlayCodes = `
 const tmplLoginCorner = `
 <a href='/login' class="center-vertical"
 {{@if(it.loggedIn)}}
-aria-label="Profile"><i class="icon-ui icon-ui-user"></i></a>
+aria-label="Account"><i class="icon-ui icon-ui-user"></i></a>
 {{#else}}
 >Login</a>
 {{/if}}
@@ -948,25 +948,6 @@ async function loadAllBuilds() {
     }
 }
 
-function setupCollapsibles() {
-    // UI utilities
-    // See the collapsible css styles in ui.css.
-    var coll = document.getElementsByClassName("collapsible");
-    var i;
-    for (i = 0; i < coll.length; i++) {
-        coll[i].addEventListener("click", function () {
-            console.log("collapse");
-            this.classList.toggle("active");
-            var content = this.nextElementSibling;
-            if (content.style.display === "block") {
-                content.style.display = "none";
-            } else {
-                content.style.display = "block";
-            }
-        });
-    }
-}
-
 async function checkStillLoggedIn() {
     try {
         // 2. Use 'await' to wait for the fetch request to complete
@@ -1002,7 +983,7 @@ async function checkStillLoggedIn() {
 function onLoadPage() {
     loadCredentials();
     applyDOMVisibility();
-    setupCollapsibles();
+
     if (g_thankYouPage) {
         window.setTimeout(pollPurchase, g_pollInterval);
     }
@@ -1023,16 +1004,6 @@ function onLoadPage() {
     if (typeof hljs !== 'undefined') {
         console.log("highlighting");
         hljs.highlightAll();
-    }
-
-    // Make the burger button keyboard accessible
-    var toggleButton = document.getElementById('burgerButton');
-    if (toggleButton) {
-        toggleButton.addEventListener('keydown', function (event) {
-            if (event.key === 'Enter') {
-                burgerClick();
-            }
-        });
     }
 
     // Close the content when clicking outside the div

--- a/template/cat_contents.hbs
+++ b/template/cat_contents.hbs
@@ -2,11 +2,13 @@
 
 {{{ contents }}}
 
-{{ #each children }}
-<nav aria-label="Documents in this category" class="nav-link-container">
-    <a href="{{url}}" class="nav-link">
-        <div class="title">{{title}}</div>
-        <div class="direction">{{#if summary}}{{{summary}}}<br>Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}</div>
-    </a>
+<nav aria-label="Documents in this category">
+    {{ #each children }}
+    <div class="nav-link-container">
+        <a href="{{url}}" class="nav-link">
+            <div class="title">{{title}}</div>
+            <div class="direction">{{#if summary}}{{{summary}}}<br>Read more&nbsp;&raquo;{{else}}Read&nbsp;&raquo;{{/if}}</div>
+        </a>
+    </div>
+    {{ /each }}
 </nav>
-{{ /each }}

--- a/template/common_header.hbs
+++ b/template/common_header.hbs
@@ -30,24 +30,27 @@
 
     <script src="/static/script/squirrelly.min.js" defer></script>
     <script src="/static/script/main.js" defer></script>
+
     {{#unless noAds}}
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3281131109267988"
         crossorigin="anonymous"></script>
     {{/unless}}
+
+    {{!-- Special behaviors. There's probably a better way. --}}
     <script>
-        // Special behaviors. There's probably a better way.
         var g_loginByKey = false;
         var g_thankYouPage = false;
         var g_downloadPage = false;
         var g_buildbotPage = false;
     </script>
+
     {{#if fastspring}}
-    <script id="fsc-api" src="https://d1f8f9xcsvx3ha.cloudfront.net/sbl/0.7.4/fastspring-builder.min.js" {{#if
-        globals.prod}} data-storefront="ppsspp.onfastspring.com/popup-gold" {{else}}
-        data-storefront="ppsspp.test.onfastspring.com/popup-gold" {{/if}} data-popup-closed="onFSPopupClosed"
-        data-error-callback="onFSError" data-debug=true>
-        </script>
+    <script id="fsc-api" src="https://d1f8f9xcsvx3ha.cloudfront.net/sbl/0.7.4/fastspring-builder.min.js"
+        {{#if globals.prod}} data-storefront="ppsspp.onfastspring.com/popup-gold"
+        {{else}} data-storefront="ppsspp.test.onfastspring.com/popup-gold" {{/if}}
+        data-popup-closed="onFSPopupClosed" data-error-callback="onFSError" data-debug=true></script>
     {{/if}}
+
     {{#if contains_code}}
     <script src="/static/script/highlight.min.js" defer></script>
     {{/if}}
@@ -57,14 +60,16 @@
     <div class="page-wrapper">
         <header role="banner">
             <nav role="navigation" aria-label="Desktop navigation" class="top-nav">
-                <div role="button" aria-label="Open mobile navigation" class='menu-button-container' id="burgerButton"
-                        onclick="burgerClick()" tabindex="0">
-                    <div class='menu-button'></div>
-                </div>
+                <button type="button" id="burgerButton" aria-label="Toggle mobile navigation" class="menu-button"
+                        onclick="burgerClick()">
+                    <div class="menu-icon"></div>
+                </button>
+
                 <div class="top-nav-logo">
                     <a href="/" class="center-vertical"><img id="navbarIcon" src="/static/img/platform/ppsspp-icon.png" alt="" aria-hidden="true"
                             width="32" height="32" class="icon">PPSSPP</a>
                 </div>
+
                 <ul class="menu">
                     {{#each top_nav}}
                     <li {{#if external}}class="external"{{/if}}>
@@ -72,15 +77,16 @@
                     </li>
                     {{/each}}
                     <li>
-                        <div class="switch-theme" onclick="switchTheme()">
-                            <i role="button" aria-label="Switch Theme" class="icon-ui icon-ui-moon"></i>
-                        </div>
+                        <button type="button" aria-label="Switch theme" onclick="switchTheme()">
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon"></i>
+                        </button>
                     </li>
                 </ul>
-                <div id="loginCorner"><a href="/login">Login</a></div>
+
+                <div id="loginCorner" class="center-vertical"><a href="/login">Login</a></div>
             </nav>
 
-            <nav role="navigation" aria-label="Mobile navigation" class="burger-sidebar hidden" id="rootSidebar">
+            <nav role="navigation" id="rootSidebar" aria-label="Mobile navigation" class="burger-sidebar hidden">
                 {{!-- We repeat all the same stuff again, but add Login. Better than crazy CSS tricks... --}}
                 <ul class="burger-menu">
                     {{#each top_nav}}
@@ -90,8 +96,8 @@
                         <div id="loginItem"><a href="/login">Login</a></div>
                     </li>
                     <li>
-                        <div id="darkItem" class="switch-theme" onclick="switchTheme()">
-                            <i aria-hidden="true" class="icon-ui icon-ui-moon sp-right"></i>Switch Theme</div>
+                        <button role="button" onclick="switchTheme()">
+                            <i aria-hidden="true" class="icon-ui icon-ui-moon sp-right"></i>Switch Theme</button>
                     </li>
                 </ul>
             </nav>


### PR DESCRIPTION
- Convert all `<div>` elements with an `onclick` attribute (aka fake buttons) into proper `<button>` elements. These were present in the top navigation bar, the hamburger menu and in the gallery.
  - Fix up related CSS, remove now unused classes / selectors.
  - Remove now unused JS script for making the hamburger button keyboard accessible. This is handled natively by the `<button>` element.
- Convert all `<button>` elements with the `collapsible` (aka fake collapsible sections) class into proper `<details>`/`<summary>` pairs. These were present in the download and legacybuilds pages.
  - Fix up related CSS, remove now unused classes / selectors.
  - Remove now unused JS script for fake collapsible buttons.
- Other misc CSS cleanup.
- ARIA improvements everywhere I edited.

This should provide a major improvement for accessibility (keyboard navigation and screen readers).