### PR TITLE
Light mode contrast improvements

### DIFF
--- a/pages/linktest.hbs
+++ b/pages/linktest.hbs
@@ -7,6 +7,14 @@
     <p><a href="https://apps.apple.com/us/app/ppsspp-gold-psp-emulator/id6502287918">PPSSPP Gold iOS</a></p>
 
     <p><a href="/unofficial/plants.zip">Plants vs Zombies Homebrew ISO</a></p>
+
+    <p>The color contrast of links inside alert boxes requires special attention!</p>
+    <div class="alert alert-gold">This is a gold <a href="/linktest">link test</a>.</div>
+    <div class="alert alert-success">This is a success <a href="/linktest">link test</a>.</div>
+    <div class="alert alert-info">This is an info <a href="/linktest">link test</a>.</div>
+    <div class="alert alert-warning">This is a warning <a href="/linktest">link test</a>.</div>
+    <div class="alert alert-error">This is an error <a href="/linktest">link test</a>.</div>
+    <div class="alert">This is an empty <a href="/linktest">link test</a>.</div>
 </div>
 
 {{> common_footer this}}

--- a/static/css/article.css
+++ b/static/css/article.css
@@ -4,31 +4,27 @@
 }
 
 .article {
-    /* General */
     display: block;
 }
 
-.article .article-infos ul {
+ul.article-infos {
     list-style: none;
     margin: 0 0 12px 0;
     padding: 0;
 }
 
-.article .article-infos ul li {
+.article-infos li {
     display: inline-block;
     font-size: 14px;
     margin: 0 1rem 0 0;
     padding: 0;
 }
 
-.article .article-infos ul li a {
+.article-infos li a {
     color: var(--color-text);
 }
 
-.article .article-infos i {
-    color: var(--color-gray-300);
-}
-
+/* Pagination */
 a.next {
     text-align: right;
 }
@@ -43,7 +39,7 @@ a.next {
 a.nav-link {
     display: table-cell;
     border-width: 2px;
-    border-color: var(--color-gray-700);
+    border-color: var(--default-border-color);
     border-radius: 10px;
     border-style: solid;
     margin: 20px 0px 10px 0px;
@@ -52,7 +48,7 @@ a.nav-link {
 }
 
 a.nav-link:hover {
-    border-color: var(--color-primary);
+    border-color: var(--color-a-hover);
 }
 
 a.nav-link .direction {
@@ -78,11 +74,11 @@ ul.breadcrumb {
     list-style: none;
     margin-top: 12px;
     margin-left: -5px;
-    background-color: var(--color-gray-800);
+    background-color: var(--background-surface-color);
 }
 
 /* Display list items side by side */
-ul.breadcrumb li {
+.breadcrumb li {
     display: inline;
     font-size: 14pt;
     padding-top: 5px;
@@ -90,19 +86,19 @@ ul.breadcrumb li {
 }
 
 /* Add a slash symbol (/) before/behind each list item */
-ul.breadcrumb li+li:before {
+.breadcrumb li+li:before {
     padding: 8px;
     color: var(--color-text);
     content: "/\00a0";
 }
 
 /* Add a color to all links inside the list */
-ul.breadcrumb li a {
+.breadcrumb li a {
     text-decoration: none;
 }
 
 /* Add a color on mouse-over */
-ul.breadcrumb li a:hover {
+.breadcrumb li a:hover {
     text-decoration: underline;
 }
 
@@ -114,31 +110,30 @@ ul.tag-list {
     margin-top: 12px;
 }
 
-ul.tag-list li {
+.tag-list li {
     display: inline;
     font-size: 14pt;
     padding-top: 5px;
     padding-bottom: 5px;
 }
 
-ul.tag-list li a {
+.tag-list li a {
     border-radius: 7px;
-    background-color: var(--color-gray-800);
+    background-color: var(--background-surface-color);
     padding: 8px;
     box-shadow: 0 3px 5px var(--shadow-color);
     color: var(--color-text);
     text-decoration: none;
 }
 
-ul.tag-list li a:hover {
-    color: var(--color-primary);
-    background-color: var(--color-gray-700);
-    text-decoration: none;
+.tag-list li a:hover {
+    color: var(--color-a-hover);
+    text-decoration: underline;
 }
 
-ul.tag-list li.selected a {
-    color: var(--color-primary);
-    background-color: var(--color-gray-700);
+.tag-list li.selected a {
+    color: var(--color-a);
+    background-color: var(--default-border-color);
     text-decoration: none;
 }
 
@@ -150,11 +145,11 @@ ul.tag-list li.selected a {
 }
 
 .doc-sidebar a.selected {
-    color: var(--color-primary);
+    color: var(--color-a);
 }
 
 .doc-sidebar a:hover {
-    color: var(--color-primary);
+    color: var(--color-a-hover);
 }
 
 ul.nav-tree-items {
@@ -185,7 +180,7 @@ a.nav-tree-item {
 
 a.nav-tree-category.selected,
 a.nav-tree-item.selected {
-    background-color: var(--color-gray-800);
+    background-color: var(--background-surface-color);
 }
 
 @media (pointer: coarse) {
@@ -199,10 +194,8 @@ a.nav-tree-item.selected {
 
 /* Table of contents */
 .toc {
-    border-width: 2px;
-    border-color: var(--color-gray-700);
+    border: 2px solid var(--default-border-color);
     border-radius: 10px;
-    border-style: solid;
     margin: 10px 0px;
     padding: 0px 20px 10px;
 }

--- a/static/css/gallery.css
+++ b/static/css/gallery.css
@@ -92,7 +92,7 @@
     height: 18px;
     width: 18px;
     margin: 0.5ch;
-    background-color: #bbb;
+    background-color: var(--dotnav-color);
     border: none;
     border-radius: 50%;
     display: inline-block;
@@ -101,11 +101,11 @@
 }
 
 .slideshow-dot:hover {
-    background-color: var(--color-primary);
+    background-color: var(--button-background-color);
 }
 
 .slideshow-dot.active {
-    background-color: #717171;
+    background-color: var(--button-background-color-active);
     transform: translateY(-2px);
 }
 

--- a/static/css/grid.css
+++ b/static/css/grid.css
@@ -180,7 +180,7 @@ With the addition of a special doc-container for docs with sidebars.
     overflow-x: hidden;
     min-width: var(--doc-sidebar-width);
     height: 100%;
-    border-right: 2px solid var(--color-gray-800);
+    border-right: 2px solid var(--background-surface-color);
     padding-bottom: 12px;
     margin-right: 4px;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,6 +11,7 @@
 }
   */
 
+/* Basic elements */
 html,
 body {
   font-family: DroidSans, sans-serif;
@@ -20,10 +21,6 @@ body {
   box-sizing: border-box;
   color: var(--color-text);
   background-color: var(--color-contents-background);
-}
-
-a {
-  text-decoration: none;
 }
 
 p,
@@ -60,7 +57,8 @@ h4 { font-size: 14pt; }
 .small-headers h4 { font-size: 13pt; }
 
 a {
-  color: var(--color-primary);
+  text-decoration: none;
+  color: var(--color-a);
 }
 
 a:hover {
@@ -127,7 +125,8 @@ footer a:hover {
 }
 
 footer h2 {
-  font-size: 14pt;
+  text-transform: uppercase;
+  font-size: 12pt;
   padding-bottom: 12px;
 }
 
@@ -136,12 +135,12 @@ footer h2 {
 }
 
 .footer-bottom-text a {
-  color: var(--color-primary);
+  color: var(--color-a);
 }
 
 footer {
   flex-grow: 0;
   flex-shrink: 0;
-  background-color: var(--color-header-footer);
+  background-color: var(--color-header-footer-background);
   color: var(--color-text)
 }

--- a/static/css/top-nav.css
+++ b/static/css/top-nav.css
@@ -15,7 +15,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    background-color: var(--color-header-footer);
+    background-color: var(--color-header-footer-background);
     color: var(--color-text);
     height: 60px;
     padding: 1em;
@@ -26,7 +26,7 @@
 }
 
 .top-nav a {
-    color: var(--color-gray-0);
+    color: var(--color-header-footer-a);
 }
 
 .top-nav a:hover {
@@ -34,7 +34,7 @@
 }
 
 .top-nav button {
-    color: var(--color-gray-0);
+    color: var(--color-header-footer-a);
     background: transparent;
     border: none;
     cursor: pointer;
@@ -97,7 +97,7 @@
 .menu-icon::before,
 .menu-icon::after {
     display: block;
-    background-color: var(--color-gray-0);
+    background-color: var(--color-header-footer-a);
     position: absolute;
     height: 4px;
     width: 30px;

--- a/static/css/ui.css
+++ b/static/css/ui.css
@@ -26,7 +26,7 @@
     background-color: var(--button-background-color);
     border: var(--button-border-width) solid var(--button-border-color);
     border-radius: var(--button-border-radius);
-    color: var(--color-text-inverse);
+    color: var(--button-color);
     cursor: pointer;
     font-size: calc(.875rem*var(--button-size-multiplier));
     font-weight: var(--button-font-weight);
@@ -53,7 +53,7 @@
     background-color: var(--button-background-color);
     border: var(--button-border-width) solid var(--button-border-color);
     border-radius: var(--button-border-radius);
-    color: var(--color-text-inverse);
+    color: var(--button-color);
     font-weight: var(--button-font-weight);
     padding: 4px;
     margin: 0 0.5ch;
@@ -63,58 +63,70 @@
 
 .download-button.button-gold,
 .mini-button.button-gold {
-    background-color: var(--color-gold);
-    border-color: var(--color-gold-border);
+    background-color: var(--gold-background-color);
+    border-color: var(--gold-border-color);
+    color: var(--gold-color);
 }
 
 .download-button:hover,
 .mini-button:hover {
-    color: var(--color-text-inverse);
+    color: var(--button-color);
     background-color: var(--button-background-color-hover);
     text-decoration: none;
 }
 
 .download-button.button-gold:hover,
 .mini-button.button-gold:hover {
-    background-color: var(--color-gold-hover);
-    border-color: var(--color-gold-border-hover);
+    background-color: var(--gold-background-color-hover);
+    border-color: var(--gold-border-color-hover);
+    color: var(--gold-color);
 }
 
-/* Notification boxes */
+/* Alert / notification boxes */
 .alert {
     display: block;
     box-shadow: 0 3px 5px var(--shadow-color);
-    border-radius: 5px;
+    border-radius: var(--default-border-radius);
     border-left-style: solid;
     border-width: 5px;
     padding: 14px;
     margin: 12px 0px;
-    color: #fff;
-    /* on both dark and light modes */
+    background-color: #00000040;
+    color: var(--alert-color);
 }
 
 .alert.alert-warning {
-    background-color: var(--color-warning-darkest);
-    border-color: var(--color-warning);
+    background-color: var(--alert-warning-background-color);
+    border-color: var(--alert-warning-border-color);
 }
 
 .alert.alert-error {
-    background-color: var(--color-danger-darkest);
-    border-color: var(--color-danger);
+    background-color: var(--alert-error-background-color);
+    border-color: var(--alert-error-border-color);
 }
 
 .alert.alert-success {
-    background-color: var(--color-success-darkest);
-    border-color: var(--color-success);
+    background-color: var(--alert-success-background-color);
+    border-color: var(--alert-success-border-color);
 }
 
 .alert.alert-info {
-    background-color: var(--color-primary-darkest);
-    border-color: var(--color-primary);
+    background-color: var(--alert-info-background-color);
+    border-color: var(--alert-info-border-color);
+}
+
+.alert.alert-gold {
+    background-color: var(--gold-background-color-hover);
+    border-color: var(--gold-border-color);
+    color: var(--gold-color);
 }
 
 .alert.alert-hidden {
     display: none;
+}
+
+.alert a {
+    font-weight: var(--button-font-weight);
 }
 
 /* Collapsible button */
@@ -123,8 +135,8 @@ summary {
 }
 
 .collapsible {
-    background-color: var(--color-primary);
-    color: var(--color-text-inverse);
+    background-color: var(--button-background-color);
+    color: var(--button-color);
     cursor: pointer;
     padding: 18px;
     width: 100%;
@@ -136,9 +148,13 @@ summary {
     user-select: none;
 }
 
+.collapsible:hover {
+    background-color: var(--button-background-color-hover);
+}
+
 details[open] .collapsible {
-    color: white;
-    background-color: #555;
+    color: var(--button-color-active);
+    background-color: var(--button-background-color-active);
 }
 
 /* Formatted table */
@@ -220,8 +236,8 @@ form input {
     width: 100%;
     margin: 3px 0px 13px 0px;
     height: 35px;
-    border: solid 2px var(--color-gray-600);
-    background-color: var(--color-gray-900);
+    border: solid 2px var(--default-border-color);
+    background-color: var(--color-contents-background);
     color: var(--color-text);
 }
 
@@ -232,8 +248,8 @@ form label {
 
 form textarea {
     width: 100%;
-    border: solid 2px var(--color-gray-600);
-    background-color: var(--color-gray-900);
+    border: solid 2px var(--default-border-color);
+    background-color: var(--color-contents-background);
     color: var(--color-text);
 }
 
@@ -242,7 +258,7 @@ form button {
     background-color: var(--button-background-color);
     border: var(--button-border-width) solid var(--button-border-color);
     border-radius: var(--button-border-radius);
-    color: var(--color-text-inverse);
+    color: var(--button-color);
     cursor: pointer;
     font-size: calc(.875rem*var(--button-size-multiplier));
     font-weight: var(--button-font-weight);
@@ -258,7 +274,7 @@ form button {
 }
 
 form button:hover {
-    color: var(--color-text-inverse);
+    color: var(--button-color);
     background-color: var(--button-background-color-hover);
     text-decoration: none;
 }
@@ -267,6 +283,9 @@ form button:hover {
 .video {
     aspect-ratio: 16 / 9;
     width: 100%;
+    height: auto;
+    object-fit: contain;
+    border-radius: var(--default-border-radius);
 }
 
 .forgot-password {
@@ -283,7 +302,8 @@ code {
   border-radius: 6px;
   padding: .2em .4em;
   margin: 0;
-  background-color: var(--color-gray-800);
+  color: var(--color-text);
+  background-color: var(--background-surface-color);
   word-break: break-word;
   text-align: left;
 }

--- a/static/css/vars.css
+++ b/static/css/vars.css
@@ -1,11 +1,6 @@
-/* The colors are nabbed from infima (docusaurus) mainly. */
+/* Some of the colors are nabbed from Infima (Docusaurus). */
 
 html[data-theme='dark'] {
-    --default-border-radius: 5px;
-    --card-border-radius: 15px;
-
-    --doc-sidebar-width: 250px;
-
     --color-gray-0: #fff;
     --color-gray-100: #f5f6f7;
     --color-gray-200: #ebedf0;
@@ -18,16 +13,38 @@ html[data-theme='dark'] {
     --color-gray-900: #1c1e21;
     --color-gray-1000: #000;
 
+    --color-primary: #33b5e5;
+    --color-primary-dark: #2792b9;
+    --color-primary-darker: #1a627c;
+    --color-primary-darkest: #13475b;
+    --color-primary-light: #6dc9eb;
+    --color-primary-lighter: #ace9ff;
+    --color-primary-lightest: #c9f1ff;
+    --color-primary-contrast-background: #ebf2fc;
+    --color-primary-contrast-foreground: #102445;
+
+    --alert-success-background-color: var(--color-success-darkest);
+    --alert-success-border-color: var(--color-success);
+    --alert-success-a-color: var(--color-success);
+    --alert-info-background-color: var(--color-primary-darkest);
+    --alert-info-border-color: var(--color-primary);
+    --alert-warning-background-color: var(--color-warning-darkest);
+    --alert-warning-border-color: var(--color-warning);
+    --alert-error-background-color: var(--color-danger-darkest);
+    --alert-error-border-color: var(--color-danger);
+    --alert-color: var(--gray-1000);
+
+    --hero-background-color: #193858;
+    --hero-color: #fff;
+    --hero-light: #e9f1f1;
+
     --background-surface-color: var(--color-gray-800);
     --shadow-color: var(--color-gray-1000);
+    --dotnav-color: var(--color-gray-300);
+    --default-border-color: var(--color-gray-700);
 }
 
 html[data-theme='light'] {
-    --default-border-radius: 5px;
-    --card-border-radius: 15px;
-
-    --doc-sidebar-width: 250px;
-
     --color-gray-1000: #fff;
     --color-gray-900: #f5f6f7;
     --color-gray-800: #ebedf0;
@@ -40,97 +57,135 @@ html[data-theme='light'] {
     --color-gray-100: #1c1e21;
     --color-gray-0: #000;
 
+    --color-primary: #185cc2;
+    --color-primary-dark: #134897;
+    --color-primary-darker: #0d3167;
+    --color-primary-darkest: #09234a;
+    --color-primary-light: #4a8ae0;
+    --color-primary-lighter: #8cb4e8;
+    --color-primary-lightest: #b0ccf2;
+    --color-primary-contrast-background: #eef3fc;
+    --color-primary-contrast-foreground: #0a1c38;
+
+    --alert-success-background-color: var(--color-success-lightest);
+    --alert-success-border-color: var(--color-success);
+    --alert-success-a-color: var(--color-success-darkest);
+    --alert-info-background-color: var(--color-primary-lightest);
+    --alert-info-border-color: var(--color-primary);
+    --alert-warning-background-color: var(--color-warning-lightest);
+    --alert-warning-border-color: var(--color-warning);
+    --alert-error-background-color: var(--color-danger-lightest);
+    --alert-error-border-color: var(--color-danger);
+    --alert-color: var(--gray-1000);
+
+    --hero-background-color: #d0def2;
+    --hero-color: #000;
+    --hero-light: #52719c;
+
     --background-surface-color: var(--color-gray-700);
     --shadow-color: var(--color-gray-300);
+    --dotnav-color: var(--color-gray-400);
+    --default-border-color: var(--color-gray-600);
 }
 
 :root {
-    /* Shared colors */
-
-    --color-primary: #33b5e5;
+    /* Shared colors - alert / notification boxes */
+/*
     --color-secondary: #ebedf0;
+    --color-secondary-dark: #d4d5d8;
+    --color-secondary-darker: #c8c9cc;
+    --color-secondary-darkest: #a4a6a8;
+    --color-secondary-light: #eef0f2;
+    --color-secondary-lighter: #f1f2f5;
+    --color-secondary-lightest: #f5f6f8;
+    --color-secondary-contrast-background: #fdfdfe;
+    --color-secondary-contrast-foreground: #474748;
+*/
+
     --color-success: #00a400;
+    --color-success-dark: #009400;
+    --color-success-darker: #008b00;
+    --color-success-darkest: #015f01;
+    --color-success-light: #26b226;
+    --color-success-lighter: #4dbf4d;
+    --color-success-lightest: #80d280;
+    --color-success-contrast-background: #e6f6e6;
+    --color-success-contrast-foreground: #003100;
+
+/*
     --color-info: #54c7ec;
+    --color-info-dark: #4cb3d4;
+    --color-info-darker: #47a9c9;
+    --color-info-darkest: #3b8ba5;
+    --color-info-light: #6ecfef;
+    --color-info-lighter: #87d8f2;
+    --color-info-lightest: #aae3f6;
+    --color-info-contrast-background: #eef9fd;
+    --color-info-contrast-foreground: #193c47;
+*/
+
     --color-warning: #b78600;
+    --color-warning-dark: #dba100;
+    --color-warning-darker: #b98700;
+    --color-warning-darkest: #694d00;
+    --color-warning-light: #ffc426;
+    --color-warning-lighter: #ffcf4d;
+    --color-warning-lightest: #ffdd80;
+    --color-warning-contrast-background: #fff8e6;
+    --color-warning-contrast-foreground: #4d3800;
+
     --color-danger: #fa383e;
+    --color-danger-dark: #e13238;
+    --color-danger-darker: #d53035;
+    --color-danger-darkest: #8c1f22;
+    --color-danger-light: #fb565b;
+    --color-danger-lighter: #fb7478;
+    --color-danger-lightest: #fd9c9f;
+    --color-danger-contrast-background: #ffebec;
+    --color-danger-contrast-foreground: #4b1113;
 
-    --color-gold: #b48700;
-    --color-gold-hover: #efb400;
-    --color-gold-border: #ffc800;
-    --color-gold-border-hover: #fff5d0;
+    /* Shared colors - buttons */
+    --gold-background-color: #b48700;
+    --gold-background-color-hover: #efb400;
+    --gold-border-color: #ffc800;
+    --gold-border-color-hover: #fff5d0;
+    --gold-color: #000;
 
-    --color-primary-dark: #2792b9;
-    --color-primary-darker: #1a627c;
-    --color-primary-darkest: #13475b;
-    --color-primary-light: #6dc9eb;
-    --color-primary-lighter: #ace9ff;
-    --color-primary-lightest: #c9f1ff;
-    --color-primary-contrast-background: rgb(235, 242, 252);
-    --color-primary-contrast-foreground: rgb(16, 36, 69);
-    --color-secondary-dark: rgb(212, 213, 216);
-    --color-secondary-darker: rgb(200, 201, 204);
-    --color-secondary-darkest: rgb(164, 166, 168);
-    --color-secondary-light: rgb(238, 240, 242);
-    --color-secondary-lighter: rgb(241, 242, 245);
-    --color-secondary-lightest: rgb(245, 246, 248);
-    --color-secondary-contrast-background: rgb(253, 253, 254);
-    --color-secondary-contrast-foreground: rgb(71, 71, 72);
-    --color-success-dark: rgb(0, 148, 0);
-    --color-success-darker: rgb(0, 139, 0);
-    --color-success-darkest: rgb(1, 95, 1);
-    --color-success-light: rgb(38, 178, 38);
-    --color-success-lighter: rgb(77, 191, 77);
-    --color-success-lightest: rgb(128, 210, 128);
-    --color-success-contrast-background: rgb(230, 246, 230);
-    --color-success-contrast-foreground: rgb(0, 49, 0);
-    --color-info-dark: rgb(76, 179, 212);
-    --color-info-darker: rgb(71, 169, 201);
-    --color-info-darkest: rgb(59, 139, 165);
-    --color-info-light: rgb(110, 207, 239);
-    --color-info-lighter: rgb(135, 216, 242);
-    --color-info-lightest: rgb(170, 227, 246);
-    --color-info-contrast-background: rgb(238, 249, 253);
-    --color-info-contrast-foreground: rgb(25, 60, 71);
-    --color-warning-dark: rgb(219, 161, 0);
-    --color-warning-darker: rgb(185, 135, 0);
-    --color-warning-darkest: rgb(105, 77, 0);
-    --color-warning-light: rgb(255, 196, 38);
-    --color-warning-lighter: rgb(255, 207, 77);
-    --color-warning-lightest: rgb(255, 221, 128);
-    --color-warning-contrast-background: rgb(255, 248, 230);
-    --color-warning-contrast-foreground: rgb(77, 56, 0);
-    --color-danger-dark: rgb(225, 50, 56);
-    --color-danger-darker: rgb(213, 48, 53);
-    --color-danger-darkest: rgb(140, 31, 34);
-    --color-danger-light: rgb(251, 86, 91);
-    --color-danger-lighter: rgb(251, 116, 120);
-    --color-danger-lightest: rgb(253, 156, 159);
-    --color-danger-contrast-background: rgb(255, 235, 236);
-    --color-danger-contrast-foreground: rgb(75, 17, 19);
+    --button-background-color-active: #555;
+    --button-color-active: #fff;
 
-}
-
-:root {
-    /* UI parts, derived colors */
-    --color-header-footer: var(--color-gray-1000);
+    /* Derived colors */
     --color-contents-background: var(--color-gray-900);
+    --color-card-background: var(--background-surface-color);
+
     --color-text: var(--color-gray-100);
     --color-text-inverse: var(--color-gray-900);
 
-    --color-table-border: var(--color-gray-600);
-    --color-a-hover: var(--color-primary);
+    --color-a: var(--color-primary);
+    --color-a-hover: var(--color-a);
+
     --color-table-bg: var(--color-gray-800);
-    --color-card-background: var(--background-surface-color);
+    --color-table-border: var(--color-gray-600);
+
+    --color-header-footer-a: var(--color-gray-0);
+    --color-header-footer-background: var(--color-gray-1000);
 
     --button-background-color: var(--color-primary);
     --button-background-color-hover: var(--color-primary-light);
     --button-border-color: var(--button-background-color);
-    --button-border-width: 2px;
     --button-color: var(--color-text-inverse);
+
+    /* Other UI properties */
+    --button-border-width: 2px;
     --button-font-weight: bold;
     --button-padding-horizontal: 1rem;
     --button-padding-vertical: .8rem;
     --button-transition-duration: var(--transition-fast);
     --button-border-radius: 5px;
     --button-group-spacing: 2px;
+
+    --default-border-radius: 5px;
+    --card-border-radius: 15px;
+
+    --doc-sidebar-width: 250px;
 }

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -7,30 +7,28 @@
         {{/if}}
     </div>
 
-    <div class="article-infos">
-        <ul>
-            {{#with (lookup globals.authors meta.author)}}
-            <li>
-                {{#if image_url}}<img src="{{ image_url }}" alt="" aria-hidden="true" width="24" height="24" class="icon pfp">
-                {{else}}<i aria-hidden="true" class="icon-ui icon-ui-user icon-ui-24"></i>
-                {{/if}}
-                <b>{{name}}</b>
-            </li>
-            <li>
-                <i aria-hidden="true" class="icon-ui icon-ui-folder"></i>
-                <b>
-                {{#each ../meta.tags}}
-                    <a href="/{{ ../../meta.section }}/tags/{{ this }}">{{this}}</a>
-                {{/each}}
-                </b>
-            </li>
-            <li><i aria-hidden="true" class="icon-ui icon-ui-clock sp-right"></i><b>{{../meta.date}}</b></li>
-            {{#if url}}<li><a href="{{ url }}" aria-label="Personal website"><i class="icon-ui icon-ui-link"></i></a></li>{{/if}}
-            {{#if twitter_url}}<li><a href="{{ twitter_url }}" aria-label="X profile"><i class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
-            {{#if github_url}}<li><a href="{{ github_url }}" aria-label="GitHub profile"><i class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
-            {{/with}}
-        </ul>
-    </div>
+    <ul class="article-infos">
+        {{#with (lookup globals.authors meta.author)}}
+        <li>
+            {{#if image_url}}<img src="{{ image_url }}" alt="" aria-hidden="true" width="24" height="24" class="icon pfp">
+            {{else}}<i aria-hidden="true" class="icon-ui icon-ui-user icon-ui-24"></i>
+            {{/if}}
+            <b>{{name}}</b>
+        </li>
+        <li>
+            <i aria-hidden="true" class="icon-ui icon-ui-folder"></i>
+            <b>
+            {{#each ../meta.tags}}
+                <a href="/{{ ../../meta.section }}/tags/{{ this }}">{{this}}</a>
+            {{/each}}
+            </b>
+        </li>
+        <li><i aria-hidden="true" class="icon-ui icon-ui-clock sp-right"></i><b>{{../meta.date}}</b></li>
+        {{#if url}}<li><a href="{{ url }}" aria-label="Personal website"><i class="icon-ui icon-ui-link"></i></a></li>{{/if}}
+        {{#if twitter_url}}<li><a href="{{ twitter_url }}" aria-label="X profile"><i class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
+        {{#if github_url}}<li><a href="{{ github_url }}" aria-label="GitHub profile"><i class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
+        {{/with}}
+    </ul>
 
     <div>
         {{{ contents }}}


### PR DESCRIPTION
There's still room for improvement, but this is the best I could make with the blue color.

The dark theme is mostly untouched. However, many direct values were updated to use CSS variables instead.

**Main pages**:
<img width="993" height="787" alt="image" src="https://github.com/user-attachments/assets/8b2df3df-74e9-4b6b-baea-f91930025c80" />
<img width="1026" height="407" alt="image" src="https://github.com/user-attachments/assets/65cf0fc9-571e-4cba-b548-2fb2d230a321" />
<img width="983" height="618" alt="image" src="https://github.com/user-attachments/assets/26231294-c109-45bc-a13d-928f93f83b30" />
<img width="987" height="661" alt="image" src="https://github.com/user-attachments/assets/07c1927e-8f6a-4cf6-a21c-d252a7f336f6" />

The **hero section on the front page** still needs to be themed.
I've prepared the variables for them, but the gameroll image needs to be recreated with a transparent background before this could be applied.
<img width="959" height="760" alt="image" src="https://github.com/user-attachments/assets/328ffd49-df0b-4885-8732-d27bebd05d4f" />

**Links inside alerts** still need major contrast improvements on them.
Unfortunately nothing I've tried really worked.
For now I've made them bold.

<img width="1094" height="540" alt="image" src="https://github.com/user-attachments/assets/31cf73a2-0a28-4530-9dd0-329c79faa137" />
<img width="1146" height="504" alt="image" src="https://github.com/user-attachments/assets/fa4ea37e-59b0-4b4b-b3e0-55b1795d18f8" />
